### PR TITLE
Apply fix for Jedi recognition of overloads

### DIFF
--- a/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
@@ -21,7 +21,7 @@ namespace QuantConnectStubsGenerator.Renderer
 
             if (method.Overload)
             {
-                WriteLine("@typing.overload");
+                WriteLine("@overload");
             }
 
             // In C# abstract methods and method overloads can be mixed freely

--- a/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
@@ -15,6 +15,9 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Namespace ns)
         {
+            // Fix for Jedi; Include import of typing instead of using typing.overload
+            WriteLine("from typing import overload");
+
             var usedTypes = ns
                 .GetParentClasses()
                 .SelectMany(cls => cls.GetUsedTypes())


### PR DESCRIPTION
Adjustment to make Jedi accept our overloads for autocomplete. 

Unfortunately it appears that Jedi does not support using the `typing` namespace in the decorator. I have created an [issue here](https://github.com/davidhalter/jedi/issues/1840).

So to deal to fix it we instead will use `@overload`, however this alone will break Pylance because it is now unaware of the `overload`  function without having `from typing import overload`. So I added that import to the top of our namespace generator.