### PR TITLE
Block Datasource Demo Algorithms

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 
 	// Use devcontainer Dockerfile that is based on Lean foundation image
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "dockerfile"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update; \
 
 # pip
 RUN wget -q https://bootstrap.pypa.io/pip/3.6/get-pip.py \
-	&& python3 get-pip.py \
-	&& pip install --no-cache-dir quantconnect-stubs
+	&& python3 get-pip.py
 
 # pyright
 RUN npm i -g pyright

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update; \
 
 # pip
 RUN wget -q https://bootstrap.pypa.io/pip/3.6/get-pip.py \
-	&& python3 get-pip.py
+	&& python3 get-pip.py && \
+    pip install pandas matplotlib
 
 # pyright
 RUN npm i -g pyright

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -45,11 +45,11 @@ namespace QuantConnectStubsGenerator
             };
 
             // Create our blacklisted regex list, we will skip these files in stubs generation
-            // 1. DataSource repos unnecessary projects (Under ADDITIONAL_STUBS dir, see ci_build_stubs.sh)
+            // 1. DataSource repos unnecessary projects, algorithms, etc (Under ADDITIONAL_STUBS dir, see ci_build_stubs.sh)
             // 2. Any bin CS files
             List<Regex> blacklistedRegex = new()
             {
-                new (".*Lean\\/ADDITIONAL_STUBS\\/.*(?:DataProcessing|tests|DataQueueHandlers)",  RegexOptions.Compiled), 
+                new (".*Lean\\/ADDITIONAL_STUBS\\/.*(?:DataProcessing|tests|DataQueueHandlers|Demonstration|Demostration|Algorithm)",  RegexOptions.Compiled), 
                 new(".*\\/bin\\/", RegexOptions.Compiled),
             };   
 


### PR DESCRIPTION
- Block all Algorithm files in DataSource repos (Filters: `Algorithm`, `Demostration`, `Demonstration`)
- Small dev container fixes


Tested generating stubs locally with NasdaqDataLink datasource in `ADDITIONAL_STUBS`. It correctly filtered the algorithms out of the stubs 👍🏽 