### PR TITLE
Remove pandas/matplotlib dependency version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Install integration test dependencies
         run: |
-          pip install pandas matplotlib
-          npm install --global pyright
+          pip install pandas matplotlib pyright==1.1.338
 
       - name: Run integration tests
         run: python integration/integration_tests.py

--- a/QuantConnectStubsGenerator/Renderer/SetupRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/SetupRenderer.cs
@@ -25,12 +25,6 @@ namespace QuantConnectStubsGenerator.Renderer
             var packageVersion = GetPackageVersion();
             var namespaces = GetNamespaces();
 
-            var pandasVersion = GetPythonPackageVersion("pandas");
-            var pandasVersionConstraint = pandasVersion != null ? $">={pandasVersion}" : "";
-
-            var matplotlibVersion = GetPythonPackageVersion("matplotlib");
-            var matplotlibVersionConstraint = matplotlibVersion != null ? $">={matplotlibVersion}" : "";
-
             WriteLine($@"
 from setuptools import setup
 
@@ -65,7 +59,7 @@ setup(
         ""License :: OSI Approved :: Apache Software License"",
         ""Programming Language :: Python :: 3""
     ],
-    install_requires=[""pandas{pandasVersionConstraint}"", ""matplotlib{matplotlibVersionConstraint}""],
+    install_requires=[""pandas"", ""matplotlib""],
     packages=[
 {string.Join(",\n", namespaces.Select(ns => new string(' ', 8) + $"\"{ns}\""))}
     ],
@@ -120,24 +114,6 @@ setup(
                     ns = ns.Substring(0, ns.Contains('/') ? ns.LastIndexOf('/') : ns.Length);
                     return ns.Replace('/', '.');
                 }).Distinct().OrderBy(name => name).ToList();
-        }
-
-        private string GetPythonPackageVersion(string package)
-        {
-            var dockerFilePath = Path.GetFullPath("DockerfileLeanFoundation", _leanPath);
-            if (File.Exists(dockerFilePath))
-            {
-                var dockerFileContents = File.ReadAllText(dockerFilePath);
-                var versionMatch = new Regex($@"{package}==?(\d+\.\d+\.\d+)").Match(dockerFileContents);
-
-                if (versionMatch.Success)
-                {
-                    return versionMatch.Groups[1].Value;
-                }
-            }
-
-            Logger.Warn($"{dockerFilePath} does not pin {package} to a specific version");
-            return null;
         }
     }
 }


### PR DESCRIPTION
- To improve support remove pandas/matplotlib dependency version
- Pin pyright version, causes many errors starting from newer >1.1.338 (nov 2023)