### PR TITLE
PEP8 compliant stubs

### DIFF
--- a/QuantConnectStubsGenerator/Model/Property.cs
+++ b/QuantConnectStubsGenerator/Model/Property.cs
@@ -3,10 +3,14 @@ namespace QuantConnectStubsGenerator.Model
     public class Property
     {
         public string Name { get; }
+
         public PythonType Type { get; set; }
 
         public bool Static { get; set; }
+
         public bool Abstract { get; set; }
+
+        public bool Constant { get; set; }
 
         public string Value { get; set; }
 

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -170,7 +170,7 @@ namespace QuantConnectStubsGenerator.Parser
                     Type = type,
                     Static = _currentClass.Static || HasModifier(node, "static") || HasModifier(node, "const"),
                     Abstract = _currentClass.Interface || HasModifier(node, "abstract"),
-                    Constant = HasModifier(node, "const"),
+                    Constant = HasModifier(node, "const") || (HasModifier(node, "static") && HasModifier(node, "readonly")),
                     DeprecationReason = GetDeprecationReason(node)
                 };
 

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -170,7 +170,7 @@ namespace QuantConnectStubsGenerator.Parser
                     Type = type,
                     Static = _currentClass.Static || HasModifier(node, "static") || HasModifier(node, "const"),
                     Abstract = _currentClass.Interface || HasModifier(node, "abstract"),
-                    Constant = HasModifier(node, "const") || HasModifier(node, "readonly"),
+                    Constant = HasModifier(node, "const"),
                     DeprecationReason = GetDeprecationReason(node)
                 };
 

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -57,6 +57,7 @@ namespace QuantConnectStubsGenerator.Parser
                     : _currentClass.Properties.Count.ToString(),
                 Static = true,
                 Abstract = _currentClass.Interface || HasModifier(node, "abstract"),
+                Constant = true,
                 DeprecationReason = GetDeprecationReason(node)
             };
 
@@ -169,6 +170,7 @@ namespace QuantConnectStubsGenerator.Parser
                     Type = type,
                     Static = _currentClass.Static || HasModifier(node, "static") || HasModifier(node, "const"),
                     Abstract = _currentClass.Interface || HasModifier(node, "abstract"),
+                    Constant = HasModifier(node, "const") || HasModifier(node, "readonly"),
                     DeprecationReason = GetDeprecationReason(node)
                 };
 

--- a/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
+++ b/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
@@ -1,16 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="log4net" Version="2.0.12" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
-        <PackageReference Include="QuikGraph" Version="2.3.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="log4net.config">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="log4net" Version="2.0.12" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+		<PackageReference Include="QuikGraph" Version="2.3.0" />
+		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="log4net.config">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 </Project>

--- a/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
+++ b/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
@@ -7,7 +7,7 @@
 		<PackageReference Include="log4net" Version="2.0.12" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
 		<PackageReference Include="QuikGraph" Version="2.3.0" />
-		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.*" />
+		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.30" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="log4net.config">

--- a/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
+++ b/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
@@ -7,7 +7,7 @@
 		<PackageReference Include="log4net" Version="2.0.12" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
 		<PackageReference Include="QuikGraph" Version="2.3.0" />
-		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.30" />
+		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.31" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="log4net.config">

--- a/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Python.Runtime;
 using QuantConnectStubsGenerator.Model;
 using QuantConnectStubsGenerator.Utility;
 
@@ -15,10 +14,9 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Method method)
         {
-            var snakeCasedMethod = GetSnakeCasedMethod(method);
-            if (snakeCasedMethod.Name != method.Name)
+            method = GetSnakeCasedMethod(method);
+            if (method == null)
             {
-                Render(snakeCasedMethod);
                 return;
             }
 
@@ -93,7 +91,13 @@ namespace QuantConnectStubsGenerator.Renderer
 
         private static Method GetSnakeCasedMethod(Method method)
         {
-            var snakeCasedMethod = new Method(method.Name.ToSnakeCase(), method.ReturnType)
+            var snakeCasedMethodName = method.Name.ToSnakeCase();
+            if (snakeCasedMethodName.IsPythonReservedWord())
+            {
+                return null;
+            }
+
+            var snakeCasedMethod = new Method(snakeCasedMethodName, method.ReturnType)
             {
                 Static = method.Static,
                 Overload = method.Overload,
@@ -104,7 +108,13 @@ namespace QuantConnectStubsGenerator.Renderer
 
             foreach (var parameter in method.Parameters)
             {
-                snakeCasedMethod.Parameters.Add(new Parameter(parameter.Name.ToSnakeCase(), parameter.Type)
+                var snakeCasedParameterName = parameter.Name.ToSnakeCase();
+                if (snakeCasedParameterName.IsPythonReservedWord())
+                {
+                    return null;
+                }
+
+                snakeCasedMethod.Parameters.Add(new Parameter(snakeCasedParameterName, parameter.Type)
                 {
                     VarArgs = parameter.VarArgs,
                     Value = parameter.Value

--- a/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Python.Runtime;
 using QuantConnectStubsGenerator.Model;
 using QuantConnectStubsGenerator.Utility;
 
@@ -14,6 +15,13 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Method method)
         {
+            var snakeCasedMethod = GetSnakeCasedMethod(method);
+            if (snakeCasedMethod.Name != method.Name)
+            {
+                Render(snakeCasedMethod);
+                return;
+            }
+
             if (method.Static)
             {
                 WriteLine("@staticmethod");
@@ -81,6 +89,29 @@ namespace QuantConnectStubsGenerator.Renderer
             }
 
             return str;
+        }
+
+        private static Method GetSnakeCasedMethod(Method method)
+        {
+            var snakeCasedMethod = new Method(method.Name.ToSnakeCase(), method.ReturnType)
+            {
+                Static = method.Static,
+                Overload = method.Overload,
+                Summary = method.Summary,
+                File = method.File,
+                DeprecationReason = method.DeprecationReason
+            };
+
+            foreach (var parameter in method.Parameters)
+            {
+                snakeCasedMethod.Parameters.Add(new Parameter(parameter.Name.ToSnakeCase(), parameter.Type)
+                {
+                    VarArgs = parameter.VarArgs,
+                    Value = parameter.Value
+                });
+            }
+
+            return snakeCasedMethod;
         }
     }
 }

--- a/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using Python.Runtime;
 using QuantConnectStubsGenerator.Model;
 using QuantConnectStubsGenerator.Utility;
 
@@ -13,10 +12,9 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Property property)
         {
-            var snakeCasedProperty = GetSnakeCasedProperty(property);
-            if (snakeCasedProperty.Name != property.Name)
+            property = GetSnakeCasedProperty(property);
+            if (property == null)
             {
-                Render(snakeCasedProperty);
                 return;
             }
 
@@ -32,10 +30,10 @@ namespace QuantConnectStubsGenerator.Renderer
 
         private static Property GetSnakeCasedProperty(Property property)
         {
-            var name = property.Name.ToSnakeCase();
-            if (property.Constant)
+            var name = property.Name.ToSnakeCase(property.Constant);
+            if (name.IsPythonReservedWord())
             {
-                name = name.ToUpper();
+                return null;
             }
 
             return new Property(name)

--- a/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Python.Runtime;
 using QuantConnectStubsGenerator.Model;
 using QuantConnectStubsGenerator.Utility;
 
@@ -12,6 +13,13 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Property property)
         {
+            var snakeCasedProperty = GetSnakeCasedProperty(property);
+            if (snakeCasedProperty.Name != property.Name)
+            {
+                Render(snakeCasedProperty);
+                return;
+            }
+
             if (property.Static)
             {
                 RenderAttribute(property);
@@ -20,6 +28,26 @@ namespace QuantConnectStubsGenerator.Renderer
             {
                 RenderProperty(property);
             }
+        }
+
+        private static Property GetSnakeCasedProperty(Property property)
+        {
+            var name = property.Name.ToSnakeCase();
+            if (property.Constant)
+            {
+                name = name.ToUpper();
+            }
+
+            return new Property(name)
+            {
+                Type = property.Type,
+                Static = property.Static,
+                Abstract = property.Abstract,
+                Constant = property.Constant,
+                Value = property.Value,
+                Summary = property.Summary,
+                DeprecationReason = property.DeprecationReason
+            };
         }
 
         private void RenderAttribute(Property property)

--- a/QuantConnectStubsGenerator/Utility/StringExtensions.cs
+++ b/QuantConnectStubsGenerator/Utility/StringExtensions.cs
@@ -1,9 +1,17 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace QuantConnectStubsGenerator.Utility
 {
     public static class StringExtensions
     {
+        private static readonly HashSet<string> _reservedPythonWord = new HashSet<string>()
+        {
+            "and", "as", "assert", "break", "class", "continue", "def", "del", "elif", "else", "except",
+            "False", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "None",
+            "nonlocal", "not", "or", "pass", "raise", "return", "True", "try", "while", "with", "yield"
+        };
+
         public static string Indent(this string str, int level = 1)
         {
             var indentation = new string(' ', level * 4);
@@ -13,6 +21,17 @@ namespace QuantConnectStubsGenerator.Utility
                 .Select(line => indentation + line);
 
             return string.Join("\n", lines);
+        }
+
+        public static string ToSnakeCase(this string text, bool constant = false)
+        {
+            var result = Python.Runtime.Util.ToSnakeCase(text);
+            return constant ? result.ToUpperInvariant() : result;
+        }
+
+        public static bool IsPythonReservedWord(this string word)
+        {
+            return _reservedPythonWord.Contains(word);
         }
     }
 }


### PR DESCRIPTION
Generated stubs are now PEP8 compliant, following https://github.com/QuantConnect/pythonnet/pull/83, https://github.com/QuantConnect/pythonnet/pull/84 and https://github.com/QuantConnect/Lean/pull/7909