### PR TITLE
Snake-cased parameters names in docs 

### DIFF
--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -206,7 +206,7 @@ namespace QuantConnectStubsGenerator.Parser
                     return line;
                 });
 
-            var xml = string.Join("\n", xmlLines).Replace("&", "&amp;");
+            var xml = string.Join("\n", xmlLines).Replace("&", "&amp;").Trim();
 
             if (!xml.StartsWith("<"))
             {

--- a/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
@@ -14,10 +14,10 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Method method)
         {
-            method = GetSnakeCasedMethod(method);
-            if (method == null)
+            var snakeCasedMethod = GetSnakeCasedMethod(method);
+            if (snakeCasedMethod != null)
             {
-                return;
+                method = snakeCasedMethod;
             }
 
             if (method.Static)
@@ -97,14 +97,20 @@ namespace QuantConnectStubsGenerator.Renderer
                 return null;
             }
 
+            if (snakeCasedMethodName == method.Name)
+            {
+                return method;
+            }
+
             var snakeCasedMethod = new Method(snakeCasedMethodName, method.ReturnType)
             {
                 Static = method.Static,
                 Overload = method.Overload,
-                Summary = method.Summary,
                 File = method.File,
                 DeprecationReason = method.DeprecationReason
             };
+
+            var summary = method.Summary;
 
             foreach (var parameter in method.Parameters)
             {
@@ -119,7 +125,11 @@ namespace QuantConnectStubsGenerator.Renderer
                     VarArgs = parameter.VarArgs,
                     Value = parameter.Value
                 });
+
+                summary = summary?.Replace(parameter.Name, snakeCasedParameterName);
             }
+
+            snakeCasedMethod.Summary = summary;
 
             return snakeCasedMethod;
         }

--- a/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
@@ -12,10 +12,10 @@ namespace QuantConnectStubsGenerator.Renderer
 
         public override void Render(Property property)
         {
-            property = GetSnakeCasedProperty(property);
-            if (property == null)
+            var snakeCasedProperty = GetSnakeCasedProperty(property);
+            if (snakeCasedProperty != null)
             {
-                return;
+                property = snakeCasedProperty;
             }
 
             if (property.Static)


### PR DESCRIPTION
Fix: Snake-cased parameters names in docs (summary)

Also fix the base parser which was skipping summaries that have regular comments above them. Example:

```csharp

// Support for option strategies trading

/// <summary>
/// Buy Option Strategy (Alias of Order)
/// </summary>
/// <param name="strategy">Specification of the strategy to trade</param>
/// <param name="quantity">Quantity of the strategy to trade</param>
/// <param name="asynchronous">Send the order asynchronously (false). Otherwise we'll block until it fills</param>
/// <param name="tag">String tag for the order (optional)</param>
/// <param name="orderProperties">The order properties to use. Defaults to <see cref="DefaultOrderProperties"/></param>
/// <returns>Sequence of order tickets</returns>
[DocumentationAttribute(TradingAndOrders)]
public IEnumerable<OrderTicket> Buy(OptionStrategy strategy, int quantity, bool asynchronous = false, string tag = "", IOrderProperties orderProperties = null)
{
...
}
```

Wa being skipped because of `// Support for option strategies trading`