### PR TITLE
Update Microsoft.CodeAnalysis.CSharp version to 4.12.0

### DIFF
--- a/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
+++ b/QuantConnectStubsGenerator/QuantConnectStubsGenerator.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="log4net" Version="2.0.12" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
 		<PackageReference Include="QuikGraph" Version="2.3.0" />
 		<PackageReference Include="QuantConnect.pythonnet" Version="2.0.41" />
 	</ItemGroup>


### PR DESCRIPTION
Update Microsoft.CodeAnalysis.CSharp version to 4.12.0 to support Net9 parsing