### PR TITLE
Document protected setters as public

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -207,6 +207,43 @@ namespace QuantConnect.OutParametersTest
             Assert.IsNull(returnType.TypeParameters[1].Namespace);
         }
 
+        [Test]
+        public void PropertiesWithProtectedSetter()
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    {
+                        "Test.cs",
+                        @"
+namespace QuantConnect.Test
+{
+    public class TestClass
+    {
+        public int TestProperty { get; protected set; }
+    }
+}"
+                    }
+                }
+            };
+
+            var result = testGenerator.GenerateModelsPublic();
+
+            var namespaces = result.GetNamespaces().ToList();
+            Assert.AreEqual(2, namespaces.Count);
+
+            var baseNameSpace = namespaces.Single(x => x.Name == "QuantConnect");
+            var testNameSpace = namespaces.Single(x => x.Name == "QuantConnect.Test");
+
+            var testClass = testNameSpace.GetClasses().Single();
+            Assert.AreEqual("TestClass", testClass.Type.Name);
+
+            var testProperty = testClass.Properties.Single();
+            Assert.AreEqual("TestProperty", testProperty.Name);
+            Assert.IsTrue(testProperty.HasSetter);
+        }
+
         private class TestGenerator : Generator
         {
             public Dictionary<string, string> Files { get; set; }

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -111,8 +111,7 @@ namespace QuantConnectStubsGenerator.Parser
                 DeprecationReason = GetDeprecationReason(node),
                 HasSetter = node.AccessorList?.Accessors.Any(x => x.Keyword.Text == "set"
                     && !HasModifier(x.Modifiers, "private")
-                    && !HasModifier(x.Modifiers, "internal")
-                    && !HasModifier(x.Modifiers, "protected")) ?? false,
+                    && !HasModifier(x.Modifiers, "internal")) ?? false,
                 Class = _currentClass
             };
 


### PR DESCRIPTION
Document protected setters as public. 
Public properties with protected sets can be assigned to since Python does not know anything about protected properties, so Python.Net allows assigning so that subclasses can use them.

Closes #35 