### PR TITLE
Improve IEnumerable type hints

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -348,36 +348,17 @@ namespace QuantConnect.Test
 
             var testClass = classes.Single(x => x.Type.Name == "TestClass");
 
-            var constructor1Overloads = testClass.Methods.Where(x => x.Name == "__init__" && x.Parameters.Count == 1).ToList();
-            Assert.AreEqual(2, constructor1Overloads.Count);
-            Assert.AreEqual(1, constructor1Overloads[0].Parameters.Count);
-            Assert.AreEqual(1, constructor1Overloads[1].Parameters.Count);
-            Assert.AreEqual("System.Collections.Generic.List[int]", constructor1Overloads[0].Parameters[0].Type.ToPythonString());
-            Assert.AreEqual("typing.Iterable[int]", constructor1Overloads[1].Parameters[0].Type.ToPythonString());
+            var constructor1 = testClass.Methods.Where(x => x.Name == "__init__" && x.Parameters.Count == 1).Single();
+            Assert.AreEqual("typing.Iterable[int]", constructor1.Parameters[0].Type.ToPythonString());
 
-            var constructor2Overloads = testClass.Methods.Where(x => x.Name == "__init__" && x.Parameters.Count == 2).ToList();
-            Assert.AreEqual(2, constructor2Overloads.Count);
-            Assert.AreEqual(2, constructor2Overloads[0].Parameters.Count);
-            Assert.AreEqual(2, constructor2Overloads[1].Parameters.Count);
-            Assert.AreEqual("int", constructor2Overloads[0].Parameters[0].Type.ToPythonString());
-            Assert.AreEqual("System.Collections.Generic.IEnumerable[int]", constructor2Overloads[0].Parameters[1].Type.ToPythonString());
-            Assert.AreEqual("int", constructor2Overloads[1].Parameters[0].Type.ToPythonString());
-            Assert.AreEqual("typing.Iterable[int]", constructor2Overloads[1].Parameters[1].Type.ToPythonString());
+            var constructor2 = testClass.Methods.Where(x => x.Name == "__init__" && x.Parameters.Count == 2).Single();
+            Assert.AreEqual("typing.Iterable[int]", constructor2.Parameters[1].Type.ToPythonString());
 
-            var method1Overloads = testClass.Methods.Where(x => x.Name == "Method1").ToList();
-            Assert.AreEqual(2, method1Overloads.Count);
-            Assert.AreEqual(1, method1Overloads[0].Parameters.Count);
-            Assert.AreEqual(1, method1Overloads[1].Parameters.Count);
-            Assert.AreEqual("System.Collections.Generic.IList[str]", method1Overloads[0].Parameters[0].Type.ToPythonString());
-            Assert.AreEqual("typing.Iterable[str]", method1Overloads[1].Parameters[0].Type.ToPythonString());
+            var method1 = testClass.Methods.Single(x => x.Name == "Method1");
+            Assert.AreEqual("typing.Iterable[str]", method1.Parameters[0].Type.ToPythonString());
 
-            var method2Overloads = testClass.Methods.Where(x => x.Name == "Method2").ToList();
-            Assert.AreEqual(2, method2Overloads.Count);
-            Assert.AreEqual(1, method2Overloads[0].Parameters.Count);
-            Assert.AreEqual(1, method2Overloads[1].Parameters.Count);
-            Assert.AreEqual("System.Collections.Generic.IList[System.Collections.Generic.List[str]]", method2Overloads[0].Parameters[0].Type.ToPythonString());
-            Assert.AreEqual("typing.Iterable[typing.Iterable[str]]", method2Overloads[1].Parameters[0].Type.ToPythonString());
-
+            var method2 = testClass.Methods.Single(x => x.Name == "Method2");
+            Assert.AreEqual("typing.Iterable[typing.Iterable[str]]", method2.Parameters[0].Type.ToPythonString());
         }
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -218,6 +218,99 @@ class TestEnumerable2(System.Collections.Generic.List[str]):
             CompareResultFiles(expectedGeneratedFiles, renderedNamespaces);
         }
 
+        [Test]
+        public void GeneratesIterableOverloadsForEnumerableParameters()
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    {
+                        "Test.cs",
+                        @"
+using System;
+using System.Collections.Generic;
+
+namespace QuantConnect.Test
+{
+    public class TestClass
+    {
+        public TestClass(int someParam, IEnumerable<int> enumerable)
+        {
+        }
+
+        public TestClass(List<int> enumerable)
+        {
+        }
+
+        public void Method1(IList<string> enumerable)
+        {
+        }
+
+        public void Method2(DateTime someParam, IList<List<string>> enumerable)
+        {
+        }
+    }
+}"
+                    }
+                }
+            };
+
+            var expectedGeneratedFiles = new[]
+            {
+                @"
+from typing import overload
+from enum import Enum
+import datetime
+import typing
+
+import QuantConnect.Test
+import System
+import System.Collections.Generic
+
+
+class TestClass(System.Object):
+    """"""This class has no documentation.""""""
+
+    @overload
+    def __init__(self, someParam: int, enumerable: System.Collections.Generic.IEnumerable[int]) -> None:
+        ...
+
+    @overload
+    def __init__(self, someParam: int, enumerable: typing.Iterable[int]) -> None:
+        ...
+
+    @overload
+    def __init__(self, enumerable: System.Collections.Generic.List[int]) -> None:
+        ...
+
+    @overload
+    def __init__(self, enumerable: typing.Iterable[int]) -> None:
+        ...
+
+    @overload
+    def method_1(self, enumerable: System.Collections.Generic.IList[str]) -> None:
+        ...
+
+    @overload
+    def method_1(self, enumerable: typing.Iterable[str]) -> None:
+        ...
+
+    @overload
+    def method_2(self, some_param: typing.Union[datetime.datetime, datetime.date], enumerable: System.Collections.Generic.IList[System.Collections.Generic.List[str]]) -> None:
+        ...
+
+    @overload
+    def method_2(self, some_param: typing.Union[datetime.datetime, datetime.date], enumerable: typing.Iterable[typing.Iterable[str]]) -> None:
+        ...
+"
+            };
+
+            testGenerator.GenerateModelsAndRender(out var context, out var renderedNamespaces);
+
+            CompareResultFiles(expectedGeneratedFiles, renderedNamespaces);
+        }
+
         private static void CompareResultFiles(string[] expectedGeneratedFiles, List<string> renderedNamespaces)
         {
             Assert.AreEqual(expectedGeneratedFiles.Length, renderedNamespaces.Count);

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -165,10 +165,6 @@ namespace QuantConnect.Test
     {
     }
 
-    /// <summary>
-    /// This will not inherit typing.Iterable directly, but IEnumerable[string] will.
-    /// __iter__ will be generated for IEnumerable[string], not for this class.
-    /// </summary>
     public class TestEnumerable2 : List<string>
     {
     }
@@ -205,11 +201,8 @@ class TestDerivedEnumerable1(TestEnumerable):
     """"""This class has no documentation.""""""
 
 
-class TestEnumerable2(System.Collections.Generic.List[str]):
-    """"""
-    This will not inherit typing.Iterable directly, but IEnumerable[string] will.
-    __iter__ will be generated for IEnumerable[string], not for this class.
-    """"""
+class TestEnumerable2(typing.Iterable[str]):
+    """"""This class has no documentation.""""""
 "
             };
 

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -266,41 +266,22 @@ import typing
 
 import QuantConnect.Test
 import System
-import System.Collections.Generic
 
 
 class TestClass(System.Object):
     """"""This class has no documentation.""""""
 
     @overload
-    def __init__(self, someParam: int, enumerable: System.Collections.Generic.IEnumerable[int]) -> None:
-        ...
-
-    @overload
     def __init__(self, someParam: int, enumerable: typing.Iterable[int]) -> None:
-        ...
-
-    @overload
-    def __init__(self, enumerable: System.Collections.Generic.List[int]) -> None:
         ...
 
     @overload
     def __init__(self, enumerable: typing.Iterable[int]) -> None:
         ...
 
-    @overload
-    def method_1(self, enumerable: System.Collections.Generic.IList[str]) -> None:
-        ...
-
-    @overload
     def method_1(self, enumerable: typing.Iterable[str]) -> None:
         ...
 
-    @overload
-    def method_2(self, some_param: typing.Union[datetime.datetime, datetime.date], enumerable: System.Collections.Generic.IList[System.Collections.Generic.List[str]]) -> None:
-        ...
-
-    @overload
     def method_2(self, some_param: typing.Union[datetime.datetime, datetime.date], enumerable: typing.Iterable[typing.Iterable[str]]) -> None:
         ...
 "

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -191,7 +191,7 @@ import System.Collections.Generic
 TestEnumerable = typing.Any
 
 
-class TestEnumerable1(System.Object, typing.Iterable[int]):
+class TestEnumerable1(System.Object, System.Collections.Generic.IEnumerable[int], typing.Iterable[int]):
     """"""This class has no documentation.""""""
 
     def __iter__(self) -> typing.Iterator[int]:

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -165,6 +165,10 @@ namespace QuantConnect.Test
     {
     }
 
+    /// <summary>
+    /// This will not inherit typing.Iterable directly, but IEnumerable[string] will.
+    /// __iter__ will be generated for IEnumerable[string], not for this class.
+    /// </summary>
     public class TestEnumerable2 : List<string>
     {
     }
@@ -201,8 +205,11 @@ class TestDerivedEnumerable1(TestEnumerable):
     """"""This class has no documentation.""""""
 
 
-class TestEnumerable2(typing.Iterable[str]):
-    """"""This class has no documentation.""""""
+class TestEnumerable2(System.Collections.Generic.List[str]):
+    """"""
+    This will not inherit typing.Iterable directly, but IEnumerable[string] will.
+    __iter__ will be generated for IEnumerable[string], not for this class.
+    """"""
 "
             };
 

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -191,7 +191,7 @@ import System.Collections.Generic
 TestEnumerable = typing.Any
 
 
-class TestEnumerable1(System.Object, System.Collections.Generic.IEnumerable[int], typing.Iterable[int]):
+class TestEnumerable1(System.Object, typing.Iterable[int]):
     """"""This class has no documentation.""""""
 
     def __iter__(self) -> typing.Iterator[int]:

--- a/QuantConnectStubsGenerator/Model/Class.cs
+++ b/QuantConnectStubsGenerator/Model/Class.cs
@@ -34,7 +34,7 @@ namespace QuantConnectStubsGenerator.Model
         public IList<Class> InnerClasses { get; } = new List<Class>();
 
         public IList<Property> Properties { get; } = new List<Property>();
-        public IList<Method> Methods { get; } = new List<Method>();
+        public HashSet<Method> Methods { get; } = new HashSet<Method>();
 
         public Class(PythonType type)
         {

--- a/QuantConnectStubsGenerator/Model/Class.cs
+++ b/QuantConnectStubsGenerator/Model/Class.cs
@@ -107,6 +107,11 @@ namespace QuantConnectStubsGenerator.Model
             return types;
         }
 
+        public override string ToString()
+        {
+            return Type.ToString();
+        }
+
         /// <summary>
         /// Returns the used types which need to be recursively iterated over in GetUsedTypes().
         /// </summary>

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -13,12 +13,13 @@
  * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace QuantConnectStubsGenerator.Model
 {
-    public class Method
+    public class Method : IEquatable<Method>
     {
         public string Name { get; }
         public PythonType ReturnType { get; set; }
@@ -41,27 +42,28 @@ namespace QuantConnectStubsGenerator.Model
             Parameters = new List<Parameter>();
         }
 
-        public Method(Method other, IEnumerable<Parameter> parameters = null)
+        public bool Equals(Method other)
         {
-            Name = other.Name;
-            ReturnType = other.ReturnType;
-            Static = other.Static;
-            Overload = other.Overload;
-            Summary = other.Summary;
-            File = other.File;
-            DeprecationReason = other.DeprecationReason;
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name
+                && Static == other.Static
+                && Overload == other.Overload
+                && File == other.File
+                && DeprecationReason == other.DeprecationReason
+                && Parameters.SequenceEqual(other.Parameters);
+        }
 
-            if (parameters != null)
-            {
-                Parameters = parameters.ToList();
-            }
-            else
-            {
-                foreach (var parameter in other.Parameters)
-                {
-                    Parameters.Add(new Parameter(parameter));
-                }
-            }
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj.GetType() == GetType() && Equals((Method)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, Static, Overload, File, DeprecationReason, Parameters);
         }
     }
 }

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -14,6 +14,7 @@
 */
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace QuantConnectStubsGenerator.Model
 {
@@ -31,12 +32,36 @@ namespace QuantConnectStubsGenerator.Model
 
         public string DeprecationReason { get; set; }
 
-        public IList<Parameter> Parameters { get; } = new List<Parameter>();
+        public IList<Parameter> Parameters { get; }
 
         public Method(string name, PythonType returnType)
         {
             Name = name;
             ReturnType = returnType;
+            Parameters = new List<Parameter>();
+        }
+
+        public Method(Method other, IEnumerable<Parameter> parameters = null)
+        {
+            Name = other.Name;
+            ReturnType = other.ReturnType;
+            Static = other.Static;
+            Overload = other.Overload;
+            Summary = other.Summary;
+            File = other.File;
+            DeprecationReason = other.DeprecationReason;
+
+            if (parameters != null)
+            {
+                Parameters = parameters.ToList();
+            }
+            else
+            {
+                foreach (var parameter in other.Parameters)
+                {
+                    Parameters.Add(new Parameter(parameter));
+                }
+            }
         }
     }
 }

--- a/QuantConnectStubsGenerator/Model/Parameter.cs
+++ b/QuantConnectStubsGenerator/Model/Parameter.cs
@@ -28,6 +28,14 @@ namespace QuantConnectStubsGenerator.Model
             Name = name;
             Type = type;
         }
+
+        public Parameter(Parameter other)
+        {
+            Name = other.Name;
+            Type = other.Type;
+            VarArgs = other.VarArgs;
+            Value = other.Value;
+        }
     }
 }
 

--- a/QuantConnectStubsGenerator/Model/Parameter.cs
+++ b/QuantConnectStubsGenerator/Model/Parameter.cs
@@ -13,9 +13,11 @@
  * limitations under the License.
 */
 
+using System;
+
 namespace QuantConnectStubsGenerator.Model
 {
-    public class Parameter
+    public class Parameter : IEquatable<Parameter>
     {
         public string Name { get; }
         public PythonType Type { get; set; }
@@ -30,11 +32,32 @@ namespace QuantConnectStubsGenerator.Model
         }
 
         public Parameter(Parameter other)
+            : this(other.Name, other.Type)
         {
-            Name = other.Name;
-            Type = other.Type;
             VarArgs = other.VarArgs;
             Value = other.Value;
+        }
+
+        public bool Equals(Parameter other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name
+                && Type.Equals(other.Type)
+                && VarArgs == other.VarArgs
+                && Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj.GetType() == GetType() && Equals((Parameter)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, Type, VarArgs, Value);
         }
     }
 }

--- a/QuantConnectStubsGenerator/Model/PythonType.cs
+++ b/QuantConnectStubsGenerator/Model/PythonType.cs
@@ -88,6 +88,11 @@ namespace QuantConnectStubsGenerator.Model
             return str;
         }
 
+        public override string ToString()
+        {
+            return ToPythonString();
+        }
+
         public bool Equals(PythonType other)
         {
             if (ReferenceEquals(null, other)) return false;

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -121,12 +121,12 @@ namespace QuantConnectStubsGenerator.Parser
             // "Cannot create consistent method ordering" errors appear when a Python class
             // extends from classes A and B where B extends from A
             // In this case we remove the direct inheritance on A
-            var interfacesToRemove = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var interfacesToRemove = new HashSet<INamedTypeSymbol>();
             foreach (var typeA in symbol.Interfaces)
             {
                 foreach (var typeB in symbol.Interfaces)
                 {
-                    if (typeB.Interfaces.Any(x => x.Equals(typeA, SymbolEqualityComparer.Default)))
+                    if (typeB.Interfaces.Any(x => x.Name == typeA.Name))
                     {
                         interfacesToRemove.Add(typeA);
                     }

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -121,12 +121,12 @@ namespace QuantConnectStubsGenerator.Parser
             // "Cannot create consistent method ordering" errors appear when a Python class
             // extends from classes A and B where B extends from A
             // In this case we remove the direct inheritance on A
-            var interfacesToRemove = new HashSet<INamedTypeSymbol>();
+            var interfacesToRemove = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             foreach (var typeA in symbol.Interfaces)
             {
                 foreach (var typeB in symbol.Interfaces)
                 {
-                    if (typeB.Interfaces.Any(x => x.Name == typeA.Name))
+                    if (typeB.Interfaces.Any(x => x.Equals(typeA, SymbolEqualityComparer.Default)))
                     {
                         interfacesToRemove.Add(typeA);
                     }

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -188,7 +188,7 @@ namespace QuantConnectStubsGenerator.Parser
                     break;
                 }
 
-                method.Parameters.Add(Utils.NormalizeParameter(parsedParameter));
+                method.Parameters.Add(parsedParameter);
 
                 if (parameter.Modifiers.Any(m => m.Text == "out"))
                 {

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -155,7 +155,6 @@ namespace QuantConnectStubsGenerator.Parser
 
             var docStrings = new List<string>();
             var outTypes = new List<PythonType>();
-            var hasListParameter = false;
 
             foreach (var parameter in parameterList)
             {
@@ -189,7 +188,7 @@ namespace QuantConnectStubsGenerator.Parser
                     break;
                 }
 
-                method.Parameters.Add(parsedParameter);
+                method.Parameters.Add(Utils.NormalizeParameter(parsedParameter));
 
                 if (parameter.Modifiers.Any(m => m.Text == "out"))
                 {
@@ -203,8 +202,6 @@ namespace QuantConnectStubsGenerator.Parser
 
                     outTypes.Add(actualType);
                 }
-
-                hasListParameter |= Utils.IsListParameterType(parsedParameter.Type);
             }
 
             // Python.NET returns a tuple if a method has out parameters
@@ -255,18 +252,6 @@ namespace QuantConnectStubsGenerator.Parser
             _currentClass.Methods.Add(method);
 
             ImprovePythonAccessorIfNecessary(method);
-
-            if (hasListParameter)
-            {
-                method.Overload = true;
-
-                // Generate overload methods
-                var overload = new Method(method, method.Parameters.Select(Utils.ConvertListParameter).ToList())
-                {
-                    Overload = true
-                };
-                _currentClass.Methods.Add(overload);
-            }
         }
 
         private Parameter ParseParameter(ParameterSyntax syntax)

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -204,7 +204,7 @@ namespace QuantConnectStubsGenerator.Parser
                     outTypes.Add(actualType);
                 }
 
-                hasListParameter |= IsListParameterType(parsedParameter.Type);
+                hasListParameter |= Utils.IsListParameterType(parsedParameter.Type);
             }
 
             // Python.NET returns a tuple if a method has out parameters
@@ -261,46 +261,12 @@ namespace QuantConnectStubsGenerator.Parser
                 method.Overload = true;
 
                 // Generate overload methods
-                var overload = new Method(method,
-                    method.Parameters.Select(p => ConvertListParameter(p)).ToList())
+                var overload = new Method(method, method.Parameters.Select(Utils.ConvertListParameter).ToList())
                 {
                     Overload = true
                 };
                 _currentClass.Methods.Add(overload);
             }
-        }
-
-        private static Parameter ConvertListParameter(Parameter parameter)
-        {
-            if (!IsListParameterType(parameter.Type))
-            {
-                return parameter;
-            }
-
-            return new Parameter(parameter)
-            {
-                Type = ConvertListParameterType(parameter.Type)
-            };
-        }
-
-        private static PythonType ConvertListParameterType(PythonType type)
-        {
-            if (!IsListParameterType(type))
-            {
-                return type;
-            }
-
-            return new PythonType("Iterable", "typing")
-            {
-                TypeParameters = { ConvertListParameterType(type.TypeParameters[0]) }
-            };
-        }
-
-        private static bool IsListParameterType(PythonType type)
-        {
-            return type.Namespace == "System.Collections.Generic" &&
-                type.TypeParameters.Count == 1 &&
-                (type.Name == "IReadOnlyCollection" || type.Name == "IEnumerable" || type.Name == "IList" || type.Name == "List");
         }
 
         private Parameter ParseParameter(ParameterSyntax syntax)
@@ -417,8 +383,6 @@ namespace QuantConnectStubsGenerator.Parser
                 };
                 _currentClass.Methods.Add(new Method("__iter__", iteratorType));
             }
-
-            _currentClass.Type.IsIterable = true;
         }
 
         private void AddContainerMethodsIfNecessary(MethodDeclarationSyntax node)

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -31,7 +31,7 @@ namespace QuantConnectStubsGenerator.Parser
 
         public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
-            var returnType = _typeConverter.GetType(node.ReturnType);
+            var returnType = Utils.NormalizeType(_typeConverter.GetType(node.ReturnType));
             VisitMethod(
                 node,
                 node.Identifier.Text,
@@ -61,7 +61,7 @@ namespace QuantConnectStubsGenerator.Parser
                 node,
                 node.Identifier.Text,
                 node.ParameterList.Parameters,
-                _typeConverter.GetType(node.ReturnType));
+                Utils.NormalizeType(_typeConverter.GetType(node.ReturnType)));
         }
 
         public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
@@ -71,7 +71,7 @@ namespace QuantConnectStubsGenerator.Parser
                 return;
             }
 
-            var returnType = _typeConverter.GetType(node.Type);
+            var returnType = Utils.NormalizeType(_typeConverter.GetType(node.Type));
 
             // Improve the autocomplete on data[symbol] if data is a Slice and symbol a Symbol
             // In C# this is of type dynamic, which by default gets converted to typing.Any
@@ -257,7 +257,7 @@ namespace QuantConnectStubsGenerator.Parser
         private Parameter ParseParameter(ParameterSyntax syntax)
         {
             var originalName = syntax.Identifier.Text;
-            var parameter = new Parameter(FormatParameterName(originalName), _typeConverter.GetType(syntax.Type));
+            var parameter = new Parameter(FormatParameterName(originalName), Utils.NormalizeType(_typeConverter.GetType(syntax.Type)));
 
             if (syntax.Modifiers.Any(modifier => modifier.Text == "params"))
             {
@@ -382,7 +382,7 @@ namespace QuantConnectStubsGenerator.Parser
                 return;
             }
 
-            VisitMethod(node, "__contains__", node.ParameterList.Parameters, _typeConverter.GetType(node.ReturnType));
+            VisitMethod(node, "__contains__", node.ParameterList.Parameters, Utils.NormalizeType(_typeConverter.GetType(node.ReturnType)));
 
             if (_currentClass.Methods.All(m => m.Name != "__len__"))
             {

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -30,19 +30,19 @@ namespace QuantConnectStubsGenerator.Parser
 
         public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
         {
-            VisitProperty(node, _typeConverter.GetType(node.Type), node.Identifier.Text);
+            VisitProperty(node, Utils.NormalizeType(_typeConverter.GetType(node.Type)), node.Identifier.Text);
         }
 
         public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
         {
-            VisitField(node, _typeConverter.GetType(node.Declaration.Type));
+            VisitField(node, Utils.NormalizeType(_typeConverter.GetType(node.Declaration.Type)));
         }
 
         public override void VisitEventDeclaration(EventDeclarationSyntax node)
         {
             CreateEventContainerIfNecessary();
 
-            var callableType = _typeConverter.GetType(node.Type);
+            var callableType = Utils.NormalizeType(_typeConverter.GetType(node.Type));
             var type = new PythonType("_EventContainer")
             {
                 TypeParameters = {callableType, callableType.TypeParameters.Last()}
@@ -55,7 +55,7 @@ namespace QuantConnectStubsGenerator.Parser
         {
             CreateEventContainerIfNecessary();
 
-            var callableType = _typeConverter.GetType(node.Declaration.Type);
+            var callableType = Utils.NormalizeType(_typeConverter.GetType(node.Declaration.Type));
             var type = new PythonType("_EventContainer")
             {
                 TypeParameters = {callableType, callableType.TypeParameters.Last()}

--- a/QuantConnectStubsGenerator/Parser/TypeConverter.cs
+++ b/QuantConnectStubsGenerator/Parser/TypeConverter.cs
@@ -219,7 +219,7 @@ namespace QuantConnectStubsGenerator.Parser
                 };
             }
 
-            return Utils.NormalizeType(type);
+            return type;
         }
     }
 }

--- a/QuantConnectStubsGenerator/Parser/TypeConverter.cs
+++ b/QuantConnectStubsGenerator/Parser/TypeConverter.cs
@@ -16,6 +16,7 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using QuantConnectStubsGenerator.Model;
+using QuantConnectStubsGenerator.Utility;
 
 namespace QuantConnectStubsGenerator.Parser
 {
@@ -218,7 +219,7 @@ namespace QuantConnectStubsGenerator.Parser
                 };
             }
 
-            return type;
+            return Utils.NormalizeType(type);
         }
     }
 }

--- a/QuantConnectStubsGenerator/Utility/Utils.cs
+++ b/QuantConnectStubsGenerator/Utility/Utils.cs
@@ -19,7 +19,7 @@ namespace QuantConnectStubsGenerator.Utility
 {
     public static class Utils
     {
-        public static Parameter ConvertListParameter(Parameter parameter)
+        public static Parameter NormalizeParameter(Parameter parameter)
         {
             if (!IsListParameterType(parameter.Type))
             {
@@ -28,11 +28,11 @@ namespace QuantConnectStubsGenerator.Utility
 
             return new Parameter(parameter)
             {
-                Type = ConvertListParameterType(parameter.Type)
+                Type = NormalizeParameterType(parameter.Type)
             };
         }
 
-        public static PythonType ConvertListParameterType(PythonType type)
+        public static PythonType NormalizeParameterType(PythonType type)
         {
             if (!IsListParameterType(type))
             {
@@ -41,7 +41,7 @@ namespace QuantConnectStubsGenerator.Utility
 
             return new PythonType("Iterable", "typing")
             {
-                TypeParameters = { ConvertListParameterType(type.TypeParameters[0]) }
+                TypeParameters = { NormalizeParameterType(type.TypeParameters[0]) }
             };
         }
 

--- a/QuantConnectStubsGenerator/Utility/Utils.cs
+++ b/QuantConnectStubsGenerator/Utility/Utils.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnectStubsGenerator.Model;
+
+namespace QuantConnectStubsGenerator.Utility
+{
+    public static class Utils
+    {
+        public static Parameter ConvertListParameter(Parameter parameter)
+        {
+            if (!IsListParameterType(parameter.Type))
+            {
+                return parameter;
+            }
+
+            return new Parameter(parameter)
+            {
+                Type = ConvertListParameterType(parameter.Type)
+            };
+        }
+
+        public static PythonType ConvertListParameterType(PythonType type)
+        {
+            if (!IsListParameterType(type))
+            {
+                return type;
+            }
+
+            return new PythonType("Iterable", "typing")
+            {
+                TypeParameters = { ConvertListParameterType(type.TypeParameters[0]) }
+            };
+        }
+
+        public static bool IsListParameterType(PythonType type)
+        {
+            return type.Namespace == "System.Collections.Generic" &&
+                type.TypeParameters.Count == 1 &&
+                (type.Name == "IReadOnlyCollection" || type.Name == "IEnumerable" || type.Name == "IList" || type.Name == "List");
+        }
+    }
+}
+

--- a/QuantConnectStubsGenerator/Utility/Utils.cs
+++ b/QuantConnectStubsGenerator/Utility/Utils.cs
@@ -21,31 +21,31 @@ namespace QuantConnectStubsGenerator.Utility
     {
         public static Parameter NormalizeParameter(Parameter parameter)
         {
-            if (!IsListParameterType(parameter.Type))
+            if (!IsListType(parameter.Type))
             {
                 return parameter;
             }
 
             return new Parameter(parameter)
             {
-                Type = NormalizeParameterType(parameter.Type)
+                Type = NormalizeType(parameter.Type)
             };
         }
 
-        public static PythonType NormalizeParameterType(PythonType type)
+        public static PythonType NormalizeType(PythonType type)
         {
-            if (!IsListParameterType(type))
+            if (!IsListType(type))
             {
                 return type;
             }
 
             return new PythonType("Iterable", "typing")
             {
-                TypeParameters = { NormalizeParameterType(type.TypeParameters[0]) }
+                TypeParameters = { NormalizeType(type.TypeParameters[0]) }
             };
         }
 
-        public static bool IsListParameterType(PythonType type)
+        public static bool IsListType(PythonType type)
         {
             return type.Namespace == "System.Collections.Generic" &&
                 type.TypeParameters.Count == 1 &&


### PR DESCRIPTION
- Make sure all classes that extende `IEnumerable` extend Python's `typing.Iterable` and implement `__iter__` and `__next__` so that type hints allow iterating C#'s enumerables in Python, which is handled by Python.Net.
- Replace "list" type parameters, return types and property/field types (`IEnumerable`, `List`, `IList`) with `typing.Iterable`, so that type hinting allows passing in Python interables, which is also handled by Python.Net.

Closes #34 
Closes #36 