### PR TITLE
Correctly model generic methods

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -267,7 +267,7 @@ class TestClass(System.Object):
     """"""This class has no documentation.""""""
 
     @overload
-    def __init__(self, someParam: int, enumerable: typing.Iterable[int]) -> None:
+    def __init__(self, some_param: int, enumerable: typing.Iterable[int]) -> None:
         ...
 
     @overload

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -256,6 +256,8 @@ namespace QuantConnectStubsGenerator
                 "QCAlgorithm.Quit"
             };
 
+            HandleGenericMethods(cls);
+
             var pythonMethodsToRemove = cls.Methods
                 .Where(m => m.File != null && m.File.EndsWith(".Python.cs"))
                 // Python implementations of logging methods accept any parameter type
@@ -284,8 +286,6 @@ namespace QuantConnectStubsGenerator
 
                 cls.Methods.Remove(pythonMethod);
             }
-
-            HandleGenericMethods(cls);
         }
 
         private void MarkOverloads(Class cls)

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -256,8 +256,6 @@ namespace QuantConnectStubsGenerator
                 "QCAlgorithm.Quit"
             };
 
-            HandleGenericMethods(cls);
-
             var pythonMethodsToRemove = cls.Methods
                 .Where(m => m.File != null && m.File.EndsWith(".Python.cs"))
                 // Python implementations of logging methods accept any parameter type
@@ -279,13 +277,15 @@ namespace QuantConnectStubsGenerator
 
             foreach (var pythonMethod in pythonMethodsToRemove)
             {
-                foreach (var otherMethod in cls.Methods.Where(m => m.Name == pythonMethod.Name))
+                foreach (var otherMethod in cls.Methods.Where(m => m.Name == pythonMethod.Name && !m.IsGeneric))
                 {
                     otherMethod.ReturnType = pythonMethod.ReturnType;
                 }
 
                 cls.Methods.Remove(pythonMethod);
             }
+
+            HandleGenericMethods(cls);
         }
 
         private void MarkOverloads(Class cls)

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -256,6 +256,8 @@ namespace QuantConnectStubsGenerator
                 "QCAlgorithm.Quit"
             };
 
+            HandleGenericMethods(cls);
+
             var pythonMethodsToRemove = cls.Methods
                 .Where(m => m.File != null && m.File.EndsWith(".Python.cs"))
                 // Python implementations of logging methods accept any parameter type
@@ -400,6 +402,53 @@ namespace QuantConnectStubsGenerator
             return normalizedPath.EndsWith("/")
                 ? normalizedPath.Substring(0, path.Length - 1)
                 : normalizedPath;
+        }
+
+        /// <summary>
+        /// Helper method to support 'self.history(...)' and 'self.history[XYZ](...)' use cases at the same time. Solution is of the format:
+        ///
+        /// class MyClass :
+        ///     class History :
+        ///         class History(typing.Generic[T]):
+        ///              def __call__(self, ticker: str) -> list[QuantConnect.Data.Market.DataDictionary[T]]: ...
+        ///         def __call__(self, ticker: str) -> pandas.DataFrame: ...
+        ///         def __getitem__(self, type: typing.Type[T]) -> History[T]: ...
+        ///     @property
+        ///     def history(self) -> History: ...
+        /// </summary>
+        private void HandleGenericMethods(Class cls)
+        {
+            // For all generic methods we need to perform a workaround see https://github.com/QuantConnect/quantconnect-stubs-generator/issues/38
+            var genericMethodNames = cls.Methods.Where(x => x.IsGeneric).Select(x => x.Name).ToHashSet();
+            foreach (var genericMethodName in genericMethodNames)
+            {
+                var genericType = cls.Methods.Where(x => x.IsGeneric && x.Name == genericMethodName).First().GenericType;
+                var genericClassType = new PythonType(genericMethodName) { TypeParameters = [genericType] };
+                var newGenericClass = new Class(genericClassType) { Summary = string.Empty };
+                var newIndexableClass = new Class(new PythonType(genericMethodName)) { Summary = string.Empty };
+                var indexer = new Method("__getitem__", newGenericClass.Type);
+                indexer.Parameters.Add(new Parameter("type", new PythonType("Type", "typing") { TypeParameters = [genericType] }));
+                newIndexableClass.Methods.Add(indexer);
+                foreach (var methods in cls.Methods.Where(x => x.Name == genericMethodName))
+                {
+                    var targetClass = newIndexableClass;
+                    if (methods.IsGeneric)
+                    {
+                        targetClass = newGenericClass;
+                    }
+                    targetClass.Methods.Add(new Method("__call__", methods) { Overload = true });
+                }
+                var property = new Property(genericMethodName)
+                {
+                    Type = newIndexableClass.Type,
+                    Class = cls,
+                };
+                cls.Properties.Add(property);
+                cls.InnerClasses.Add(newIndexableClass);
+                newIndexableClass.InnerClasses.Add(newGenericClass);
+                // remove those we've moved around
+                cls.Methods.RemoveWhere(x => x.Name.Equals(genericMethodName, StringComparison.InvariantCultureIgnoreCase));
+            }
         }
 
         protected virtual TextWriter CreateWriter(string path)

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -31,6 +31,10 @@ namespace QuantConnectStubsGenerator.Model
 
         public string File { get; set; }
 
+        public bool IsGeneric => GenericType != null;
+
+        public PythonType GenericType { get; set; }
+
         public string DeprecationReason { get; set; }
 
         public IList<Parameter> Parameters { get; }
@@ -40,6 +44,17 @@ namespace QuantConnectStubsGenerator.Model
             Name = name;
             ReturnType = returnType;
             Parameters = new List<Parameter>();
+        }
+        public Method(string name, Method other) : this(name, other.ReturnType)
+        {
+            File = other.File;
+            Static = other.Static;
+            Summary = other.Summary;
+            Overload = other.Overload;
+            ReturnType = other.ReturnType;
+            Parameters = other.Parameters;
+            GenericType = other.GenericType;
+            DeprecationReason = other.DeprecationReason;
         }
 
         public bool Equals(Method other)

--- a/QuantConnectStubsGenerator/Renderer/ClassRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/ClassRenderer.cs
@@ -14,9 +14,9 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using QuantConnectStubsGenerator.Model;
 
 namespace QuantConnectStubsGenerator.Renderer
@@ -108,7 +108,9 @@ namespace QuantConnectStubsGenerator.Renderer
             var orderedMethods = cls.Methods
                 .Where(m => !string.IsNullOrEmpty(m.Name))
                 .OrderBy(m => m.Name)
-                .ThenBy(m => m.DeprecationReason == null ? 0 : 1);
+                .ThenBy(m => m.DeprecationReason == null ? 0 : 1)
+                // pyobjects are converted into typing.any, we want those at the top so they resolve first which is what actually happens
+                .ThenBy(m => m.Parameters.Any(x => x.Type.Name.Equals("Any")) ? 0 : 1);
 
             foreach (var method in orderedMethods)
             {

--- a/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/MethodRenderer.cs
@@ -113,11 +113,6 @@ namespace QuantConnectStubsGenerator.Renderer
                 return null;
             }
 
-            if (snakeCasedMethodName == method.Name)
-            {
-                return method;
-            }
-
             var snakeCasedMethod = new Method(snakeCasedMethodName, method.ReturnType)
             {
                 Static = method.Static,
@@ -130,6 +125,10 @@ namespace QuantConnectStubsGenerator.Renderer
 
             foreach (var parameter in method.Parameters)
             {
+                if (parameter.Name.StartsWith("*"))
+                {
+                    return method;
+                }
                 var snakeCasedParameterName = parameter.Name.ToSnakeCase();
                 if (snakeCasedParameterName.IsPythonReservedWord())
                 {


### PR DESCRIPTION
Adding helper method to support 'self.history(...)' and 'self.history[XYZ](...)' use cases at the same time. Closes https://github.com/QuantConnect/quantconnect-stubs-generator/issues/38