### PR TITLE
Improve params stubs handling

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -502,7 +502,7 @@ namespace QuantConnect.Test
             Assert.IsNull(internalFieldEvent);
         }
 
-        private class TestGenerator : Generator
+        internal class TestGenerator : Generator
         {
             public Dictionary<string, string> Files { get; set; }
             public TestGenerator() : base("/", "/", "/")

--- a/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
+++ b/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2025 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Linq;
+using NUnit.Framework;
+using static QuantConnectStubsGenerator.Tests.GeneratorTests;
+
+namespace QuantConnectStubsGenerator.Tests
+{
+    [TestFixture]
+    public class MethodParserTests
+    {
+        [Test]
+        public void ParamsHandling()
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    { "Test.cs", @"
+namespace QuantConnect.MethodParserTests
+{
+    public class TestClass
+    {
+        public int ParamsTestMethod(params string[] tickers)
+        {
+            return 1;
+        }
+    }
+}" }
+            }
+            };
+
+            var result = testGenerator.GenerateModelsPublic();
+
+            var namespaces = result.GetNamespaces().ToList();
+            Assert.AreEqual(2, namespaces.Count);
+
+            var baseNameSpace = namespaces.Single(x => x.Name == "QuantConnect");
+            var testNameSpace = namespaces.Single(x => x.Name == "QuantConnect.MethodParserTests");
+
+            var testClass = testNameSpace.GetClasses().Single();
+            Assert.AreEqual("TestClass", testClass.Type.Name);
+
+            var testMethodCount = testClass.Methods.Count;
+            Assert.AreEqual(1, testMethodCount);
+
+            var method = testClass.Methods.Single();
+
+            Assert.AreEqual(1, method.Parameters.Count);
+            Assert.AreEqual("Union", method.Parameters[0].Type.Name);
+        }
+    }
+}

--- a/QuantConnectStubsGenerator/Model/PythonType.cs
+++ b/QuantConnectStubsGenerator/Model/PythonType.cs
@@ -14,8 +14,8 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace QuantConnectStubsGenerator.Model
 {
@@ -107,12 +107,22 @@ namespace QuantConnectStubsGenerator.Model
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj.GetType() == GetType() && Equals((PythonType) obj);
+            return obj.GetType() == GetType() && Equals((PythonType)obj);
         }
 
         public override int GetHashCode()
         {
             return HashCode.Combine(Name, Namespace, Alias, IsNamedTypeParameter);
+        }
+
+        public static PythonType CreateUnion(params PythonType[] pythonTypes)
+        {
+            var unionType = new PythonType("Union", "typing");
+            foreach (var pythonType in pythonTypes ?? Enumerable.Empty<PythonType>())
+            {
+                unionType.TypeParameters.Add(pythonType);
+            }
+            return unionType;
         }
     }
 }


### PR DESCRIPTION
- `Params` parameters will use `VarArgs` and union of T of iterable of T, this was we can support python single, multiple, arrays or tuples as input (as we actually do at runtime)

```python
method([datetime(2014, 3, 25), datetime(2014, 3, 27)])
method((datetime(2014, 3, 25), datetime(2014, 3, 27)))
method(datetime(2014, 3, 25))
method(datetime(2014, 3, 25), datetime(2014, 3, 27))
```
Closes https://github.com/QuantConnect/quantconnect-stubs-generator/issues/50