### PR TITLE
Fix same name interface implementation

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -199,9 +199,6 @@ TestEnumerable = typing.Any
 class TestEnumerable1(System.Object, typing.Iterable[int]):
     """"""This class has no documentation.""""""
 
-    def __iter__(self) -> typing.Iterator[int]:
-        ...
-
     def get_enumerator(self) -> System.Collections.Generic.IEnumerator[int]:
         ...
 

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -122,12 +122,12 @@ namespace QuantConnectStubsGenerator.Parser
             // "Cannot create consistent method ordering" errors appear when a Python class
             // extends from classes A and B where B extends from A
             // In this case we remove the direct inheritance on A
-            var interfacesToRemove = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var interfacesToRemove = new HashSet<INamedTypeSymbol>();
             foreach (var typeA in symbol.Interfaces)
             {
                 foreach (var typeB in symbol.Interfaces)
                 {
-                    if (typeB.Interfaces.Contains(typeA))
+                    if (typeB.Interfaces.Any(x => x.Name == typeA.Name && x.IsGenericType == typeA.IsGenericType))
                     {
                         interfacesToRemove.Add(typeA);
                     }

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -122,12 +122,12 @@ namespace QuantConnectStubsGenerator.Parser
             // "Cannot create consistent method ordering" errors appear when a Python class
             // extends from classes A and B where B extends from A
             // In this case we remove the direct inheritance on A
-            var interfacesToRemove = new HashSet<INamedTypeSymbol>();
+            var interfacesToRemove = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             foreach (var typeA in symbol.Interfaces)
             {
                 foreach (var typeB in symbol.Interfaces)
                 {
-                    if (typeB.Interfaces.Any(x => x.Name == typeA.Name))
+                    if (typeB.Interfaces.Contains(typeA))
                     {
                         interfacesToRemove.Add(typeA);
                     }


### PR DESCRIPTION
`IEnumerable<T>` extends `IEnumerable`, but not in the stubs because the base interface was being skipped since they share names. This chain up to derived classes like `IReadOnlyCollection` or `Dictionary`, etc. which prevented those from inheriting `IEnumerable<T>`