### PR TITLE
Skip adding implicit conversion types to parameters

### DIFF
--- a/QuantConnectStubsGenerator/Model/Class.cs
+++ b/QuantConnectStubsGenerator/Model/Class.cs
@@ -35,6 +35,7 @@ namespace QuantConnectStubsGenerator.Model
 
         public IList<Property> Properties { get; } = new List<Property>();
         public HashSet<Method> Methods { get; } = new HashSet<Method>();
+        public bool AvoidImplicitTypes { get; set; }
 
         public Class(PythonType type)
         {

--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -141,11 +141,19 @@ namespace QuantConnectStubsGenerator.Parser
         }
 
         /// <summary>
+        /// Check if a node has an attribute like Obsolete or StubsIgnore.
+        /// </summary>
+        protected bool HasAttribute(SyntaxList<AttributeListSyntax> attributeList, string attribute)
+        {
+            return attributeList.Any(list => list.Attributes.Any(x => x.Name.ToString() == attribute));
+        }
+
+        /// <summary>
         /// We skip internal or private nodes
         /// </summary>
         protected bool ShouldSkip(MemberDeclarationSyntax node)
         {
-            if (node.AttributeLists.Any(list => list.Attributes.Any(x => x.Name.ToString() == "StubsIgnore")))
+            if (HasAttribute(node.AttributeLists, "StubsIgnore"))
             {
                 return true;
             }

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -67,7 +67,8 @@ namespace QuantConnectStubsGenerator.Parser
                 Summary = ParseSummary(node),
                 Interface = node is InterfaceDeclarationSyntax,
                 InheritsFrom = ParseInheritedTypes(node).ToList(),
-                MetaClass = ParseMetaClass(node)
+                MetaClass = ParseMetaClass(node),
+                AvoidImplicitTypes = HasAttribute(node.AttributeLists, "StubsAvoidImplicits")
             };
         }
 


### PR DESCRIPTION
Skip adding implicit conversion types to parameters if `StubsAvoidImplicits` attribute is found.

See https://github.com/QuantConnect/Lean/pull/8718 