### PR TITLE
Add missing __iter__ method to classes deriving IEnumerable<>

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -199,6 +199,9 @@ TestEnumerable = typing.Any
 class TestEnumerable1(System.Object, typing.Iterable[int]):
     """"""This class has no documentation.""""""
 
+    def __iter__(self) -> typing.Iterator[int]:
+        ...
+
     def get_enumerator(self) -> System.Collections.Generic.IEnumerator[int]:
         ...
 

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -365,11 +365,6 @@ namespace QuantConnectStubsGenerator.Parser
                 return;
             }
 
-            if (_currentClass.InheritsFrom.Any(t => t.Namespace == "typing" && t.Name == "Iterable"))
-            {
-                return;
-            }
-
             // Some GetEnumerator() methods return an IEnumerator, some return an IEnumerator<T>
             // typing.Iterable requires a type parameter, so we don't extend it if an IEnumerator is returned
             var typeParameters = returnType.TypeParameters;
@@ -382,7 +377,11 @@ namespace QuantConnectStubsGenerator.Parser
             {
                 TypeParameters = typeParameters
             };
-            _currentClass.InheritsFrom.Add(iterableType);
+
+            if (!_currentClass.InheritsFrom.Any(t => t.Namespace == "typing" && t.Name == "Iterable"))
+            {
+                _currentClass.InheritsFrom.Add(iterableType);
+            }
 
             if (_currentClass.Methods.All(m => m.Name != "__iter__"))
             {


### PR DESCRIPTION
Add missing __iter__ method to classes deriving IEnumerable<>

Closes #60 