### PR TITLE
Add container methods to extended dictionaries

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -366,6 +366,145 @@ class _EventContainer(typing.Generic[QuantConnect_Test__EventContainer_Callable,
         ...
 "
                 }).SetName("GeneratesEventContainerClassForEventsDelegates"),
+
+            // GeneratesContainerMethodsForDictionaries
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "IDictionary.cs",
+                        @"
+namespace System.Collections
+{
+    public interface IDictionary : ICollection
+    {
+    }
+
+    public interface IDictionary : ICollection
+    {
+    }
+}
+"
+                    },
+                    {
+                        "KeyValuePair.cs",
+                        @"
+namespace System.Collections.Generic
+{
+    public readonly struct KeyValuePair<TKey, TValue>
+    {
+    }
+}
+"
+                    },
+                    {
+                        "Test.cs",
+                        @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace QuantConnect.Test
+{
+    public class TestDictionary<TKey, TValue> : IDictionary
+    {
+        private readonly Dictionary<TValue, TKey> _data = new();
+
+        public int Count => _data.Count
+
+        public bool ContainsKey(TKey key)
+        {
+            return data.ContainsKey(key);
+        }
+    }
+
+    public class TestDictionary2<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+    {
+        private readonly List<KeyValuePair<TKey, TValue>> _data = new();
+
+        public int Count => _data.Count
+
+        public bool ContainsKey(TKey key)
+        {
+            return data.ContainsKey(key);
+        }
+    }
+}"
+                    }
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import Enum
+import abc
+
+import System.Collections
+
+class IDictionary(System.Collections.ICollection, metaclass=abc.ABCMeta):
+    """"""This class has no documentation.""""""
+",
+                    @"
+from typing import overload
+from enum import Enum
+import typing
+
+import System.Collections.Generic
+
+System_Collections_Generic_KeyValuePair_TKey = typing.TypeVar(""System_Collections_Generic_KeyValuePair_TKey"")
+System_Collections_Generic_KeyValuePair_TValue = typing.TypeVar(""System_Collections_Generic_KeyValuePair_TValue"")
+
+class KeyValuePair(typing.Generic[System_Collections_Generic_KeyValuePair_TKey, System_Collections_Generic_KeyValuePair_TValue]):
+    """"""This class has no documentation.""""""
+",
+                    @"
+from typing import overload
+from enum import Enum
+import typing
+
+import QuantConnect.Test
+import System
+import System.Collections
+import System.Collections.Generic
+
+QuantConnect_Test_TestDictionary_TKey = typing.TypeVar(""QuantConnect_Test_TestDictionary_TKey"")
+QuantConnect_Test_TestDictionary_TValue = typing.TypeVar(""QuantConnect_Test_TestDictionary_TValue"")
+QuantConnect_Test_TestDictionary2_TKey = typing.TypeVar(""QuantConnect_Test_TestDictionary2_TKey"")
+QuantConnect_Test_TestDictionary2_TValue = typing.TypeVar(""QuantConnect_Test_TestDictionary2_TValue"")
+
+class TestDictionary(typing.Generic[QuantConnect_Test_TestDictionary_TKey, QuantConnect_Test_TestDictionary_TValue], System.Object, System.Collections.IDictionary):
+    """"""This class has no documentation.""""""
+
+    @property
+    def count(self) -> int:
+        ...
+
+    def __contains__(self, key: QuantConnect_Test_TestDictionary_TKey) -> bool:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def contains_key(self, key: QuantConnect_Test_TestDictionary_TKey) -> bool:
+        ...
+
+class TestDictionary2(typing.Generic[QuantConnect_Test_TestDictionary2_TKey, QuantConnect_Test_TestDictionary2_TValue], System.Object, typing.Iterable[System.Collections.Generic.KeyValuePair[QuantConnect_Test_TestDictionary2_TKey, QuantConnect_Test_TestDictionary2_TValue]]):
+    """"""This class has no documentation.""""""
+
+    @property
+    def count(self) -> int:
+        ...
+
+    def __contains__(self, key: QuantConnect_Test_TestDictionary2_TKey) -> bool:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def contains_key(self, key: QuantConnect_Test_TestDictionary2_TKey) -> bool:
+        ...
+"
+                }).SetName("GeneratesContainerMethodsForDictionaries"),
         };
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -458,40 +458,15 @@ namespace QuantConnectStubsGenerator.Parser
 
         private void ImproveDictionaryDefinitionIfNecessary(MemberDeclarationSyntax node, Method method)
         {
-            // We add container methods to classes that implement IDictionary or IEnumerable<KeyValuePair<TKey, TValue>>,
+            // We add container methods to classes that implement Count and ContainsKey
             // because Python.Net does this to add support for operators like 'in' to work with these types
             if (node is MethodDeclarationSyntax methodNode &&
                 method.Name == "ContainsKey" &&
                 method.Parameters.Count == 1 &&
-                _currentClass.Properties.Any(property => property.Name == "Count") &&
-                (_currentClass.GetClassAndBaseClasses(_context).Any(cls => cls.Interface && (IsIDictionary(cls) || IsKeyValuePairEnumerable(cls))) ||
-                    _currentClass.InheritsFrom.Any(x => x.Name == "Iterable" && x.Namespace == "typing" && x.TypeParameters.Count == 1 && IsKeyValuePair(x))))
+                _currentClass.Properties.Any(property => property.Name == "Count"))
             {
                 AddContainerMethods(methodNode);
             }
-        }
-
-        private static bool IsIDictionary(Class cls)
-        {
-            return cls.Type.Name == "IDictionary" &&
-                cls.Type.Namespace == "System.Collections" &&
-                cls.Type.TypeParameters.Count == 0;
-        }
-
-        private static bool IsKeyValuePairEnumerable(Class cls)
-        {
-            return cls.Type.Name == "IEnumerable" && cls.Type.Namespace == "System.Collections.Generic" &&
-                cls.Type.TypeParameters.Count == 1 &&
-                cls.Type.TypeParameters[0].Name == "KeyValuePair" &&
-                cls.Type.TypeParameters[0].Namespace == "System.Collections.Generic" &&
-                cls.Type.TypeParameters[0].TypeParameters.Count == 2;
-        }
-
-        private static bool IsKeyValuePair(PythonType type)
-        {
-            return type.TypeParameters[0].Name == "KeyValuePair" &&
-                type.TypeParameters[0].Namespace == "System.Collections.Generic" &&
-                type.TypeParameters[0].TypeParameters.Count == 2;
         }
 
         /// <summary>


### PR DESCRIPTION
Add container methods to extended dictionaries, that is, classes that implement `IDictionary` or `IEnumerabe<KeyValuePair<TKey, TValue>>` interaces and `ContainsKey` method, since Pythonnet supports this (See https://github.com/QuantConnect/pythonnet/pull/99)

Closes #64 