### PR TITLE
Add missing python reserved name

### DIFF
--- a/QuantConnectStubsGenerator/Utility/StringExtensions.cs
+++ b/QuantConnectStubsGenerator/Utility/StringExtensions.cs
@@ -24,7 +24,8 @@ namespace QuantConnectStubsGenerator.Utility
         {
             "and", "as", "assert", "break", "class", "continue", "def", "del", "elif", "else", "except",
             "False", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "None",
-            "nonlocal", "not", "or", "pass", "raise", "return", "True", "try", "while", "with", "yield"
+            "nonlocal", "not", "or", "pass", "raise", "return", "True", "try", "while", "with", "yield",
+            "await"
         };
 
         public static string Indent(this string str, int level = 1)


### PR DESCRIPTION
- Add missing python reserved name. Current stubs are invalid