### PR TITLE
Support symbol implicit conversion for generic types methods

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -505,6 +505,104 @@ class TestDictionary2(typing.Generic[QuantConnect_Test_TestDictionary2_TKey, Qua
         ...
 "
                 }).SetName("GeneratesContainerMethodsForDictionaries"),
+
+            // GeneratesMethodsWithSymbolImplicitConversionForInheritedGenericClasses
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Symbol.cs",
+                        @"
+namespace QuantConnect
+{
+    public class Symbol
+    {
+    }
+}"
+                    },
+                    {
+                        "Test.cs",
+                        @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace QuantConnect.Test
+{
+    public class TestGenericClass<T1, T2>
+    {
+        public T1 TestMethod1(T1 t1Param, T2 t2Param) {}
+
+        /// <summary>
+        /// This method will not be explicitly added to TestClass because it does not need
+        /// the Symbol implicit conversion support, given that non of its parameters is directly T1
+        /// (which will be set to Symbol in the class below)
+        /// </summary>
+        public T2 TestMethod2(List<T1> t1Param, T2 t2Param) {}
+
+        public List<Dictionary<T1, T2>> TestMethod3(T1 t1Param, List<Dictionary<T1, List<T2>>> t2Param) {}
+    }
+
+    public class TestClass : TestGenericClass<Symbol, DateTime>
+    {
+    }
+}"
+                    }
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import Enum
+import QuantConnect
+import System
+
+
+class Symbol(System.Object):
+    """"""This class has no documentation.""""""
+",
+                    @"
+from typing import overload
+from enum import Enum
+import datetime
+import typing
+
+import QuantConnect
+import QuantConnect.Data.Market
+import QuantConnect.Test
+import System
+import System.Collections.Generic
+
+QuantConnect_Test_TestGenericClass_T1 = typing.TypeVar(""QuantConnect_Test_TestGenericClass_T1"")
+QuantConnect_Test_TestGenericClass_T2 = typing.TypeVar(""QuantConnect_Test_TestGenericClass_T2"")
+
+class TestGenericClass(typing.Generic[QuantConnect_Test_TestGenericClass_T1, QuantConnect_Test_TestGenericClass_T2], System.Object):
+    """"""This class has no documentation.""""""
+
+    def test_method_1(self, t_1_param: QuantConnect_Test_TestGenericClass_T1, t_2_param: QuantConnect_Test_TestGenericClass_T2) -> QuantConnect_Test_TestGenericClass_T1:
+        ...
+
+    def test_method_2(self, t_1_param: typing.List[QuantConnect_Test_TestGenericClass_T1], t_2_param: QuantConnect_Test_TestGenericClass_T2) -> QuantConnect_Test_TestGenericClass_T2:
+        """"""
+        This method will not be explicitly added to TestClass because it does not need
+        the Symbol implicit conversion support, given that non of its parameters is directly T1
+        (which will be set to Symbol in the class below)
+        """"""
+        ...
+
+    def test_method_3(self, t_1_param: QuantConnect_Test_TestGenericClass_T1, t_2_param: typing.List[System.Collections.Generic.Dictionary[QuantConnect_Test_TestGenericClass_T1, typing.List[QuantConnect_Test_TestGenericClass_T2]]]) -> typing.List[System.Collections.Generic.Dictionary[QuantConnect_Test_TestGenericClass_T1, QuantConnect_Test_TestGenericClass_T2]]:
+        ...
+
+class TestClass(QuantConnect.Test.TestGenericClass[QuantConnect.Symbol, datetime.datetime]):
+    """"""This class has no documentation.""""""
+
+    def test_method_1(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract], t_2_param: datetime.datetime) -> QuantConnect.Symbol:
+        ...
+
+    def test_method_3(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract], t_2_param: typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, typing.List[datetime.datetime]]]) -> typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, datetime.datetime]]:
+        ...
+"
+                }).SetName("GeneratesMethodsWithSymbolImplicitConversionForInheritedGenericClasses"),
         };
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -467,6 +467,11 @@ namespace QuantConnectStubsGenerator
         /// </summary>
         private void HandleSymbolGenericClass(Class cls, ParseContext context)
         {
+            if (cls.AvoidImplicitTypes)
+            {
+                return;
+            }
+
             var symbolGenericBaseClasses = cls.InheritsFrom
                 .Where(x => x.Namespace.StartsWith("QuantConnect") && x.TypeParameters.Count > 0 && x.TypeParameters.Any(y => y.Equals(PythonType.SymbolType)))
                 .ToList();
@@ -490,6 +495,11 @@ namespace QuantConnectStubsGenerator
 
                 foreach (var method in baseClass.Methods)
                 {
+                    if (method.AvoidImplicitTypes)
+                    {
+                        continue;
+                    }
+
                     var adjusted = false;
                     var adjustedMethod = new Method(method.Name, method);
                     adjustedMethod.Parameters.Clear();

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -41,6 +41,8 @@ namespace QuantConnectStubsGenerator.Model
 
         public Class Class { get; set; }
 
+        public bool AvoidImplicitTypes { get; set; }
+
         public Method(string name, PythonType returnType)
         {
             Name = name;
@@ -53,7 +55,8 @@ namespace QuantConnectStubsGenerator.Model
             Static = other.Static;
             Summary = other.Summary;
             Overload = other.Overload;
-            Parameters = other.Parameters.Select(x => x).ToList();
+            // Create a new list, so it can be modified for each method separately
+            Parameters = other.Parameters.ToList();
             GenericType = other.GenericType;
             DeprecationReason = other.DeprecationReason;
         }
@@ -62,12 +65,31 @@ namespace QuantConnectStubsGenerator.Model
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Name == other.Name
-                && Class.Equals(other.Class)
-                && Static == other.Static
-                && Overload == other.Overload
-                && GenericType == other.GenericType
-                && Parameters.SequenceEqual(other.Parameters);
+
+            if (Name != other.Name
+                || !Class.Equals(other.Class)
+                || Static != other.Static
+                || Overload != other.Overload
+                || GenericType != other.GenericType
+                || Parameters.Count != other.Parameters.Count)
+            {
+                return false;
+            }
+
+            // Don't use Parameter.Equals() because a different parameter name does not make a method different
+            for (var i = 0; i < Parameters.Count; i++)
+            {
+                var parameter = Parameters[i];
+                var otherParameter = other.Parameters[i];
+                if (!parameter.Type.Equals(otherParameter.Type)
+                    || parameter.VarArgs != otherParameter.VarArgs
+                    || parameter.Value != otherParameter.Value)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public override bool Equals(object obj)

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -53,7 +53,7 @@ namespace QuantConnectStubsGenerator.Model
             Static = other.Static;
             Summary = other.Summary;
             Overload = other.Overload;
-            Parameters = other.Parameters;
+            Parameters = other.Parameters.Select(x => x).ToList();
             GenericType = other.GenericType;
             DeprecationReason = other.DeprecationReason;
         }

--- a/QuantConnectStubsGenerator/Model/Parameter.cs
+++ b/QuantConnectStubsGenerator/Model/Parameter.cs
@@ -42,7 +42,8 @@ namespace QuantConnectStubsGenerator.Model
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Type.Equals(other.Type)
+            return Name == other.Name
+                && Type.Equals(other.Type)
                 && VarArgs == other.VarArgs
                 && Value == other.Value;
         }
@@ -56,7 +57,7 @@ namespace QuantConnectStubsGenerator.Model
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Type, VarArgs, Value);
+            return HashCode.Combine(Name, Type, VarArgs, Value);
         }
 
         public override string ToString()

--- a/QuantConnectStubsGenerator/Model/Parameter.cs
+++ b/QuantConnectStubsGenerator/Model/Parameter.cs
@@ -42,8 +42,7 @@ namespace QuantConnectStubsGenerator.Model
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Name == other.Name
-                && Type.Equals(other.Type)
+            return Type.Equals(other.Type)
                 && VarArgs == other.VarArgs
                 && Value == other.Value;
         }
@@ -57,7 +56,7 @@ namespace QuantConnectStubsGenerator.Model
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Name, Type, VarArgs, Value);
+            return HashCode.Combine(Type, VarArgs, Value);
         }
 
         public override string ToString()

--- a/QuantConnectStubsGenerator/Model/PythonType.cs
+++ b/QuantConnectStubsGenerator/Model/PythonType.cs
@@ -21,6 +21,10 @@ namespace QuantConnectStubsGenerator.Model
 {
     public class PythonType : IEquatable<PythonType>
     {
+        public static readonly PythonType SymbolType = new PythonType("Symbol", "QuantConnect");
+        public static readonly PythonType ImplicitConversionParameterSymbolType =
+            CreateUnion(SymbolType, new PythonType("str"), new PythonType("BaseContract", "QuantConnect.Data.Market"));
+
         public string Name { get; set; }
         public string Namespace { get; set; }
 
@@ -33,6 +37,14 @@ namespace QuantConnectStubsGenerator.Model
         {
             Name = name;
             Namespace = ns;
+        }
+
+        public PythonType(PythonType other)
+            : this(other.Name, other.Namespace)
+        {
+            Alias = other.Alias;
+            IsNamedTypeParameter = other.IsNamedTypeParameter;
+            TypeParameters = new List<PythonType>(other.TypeParameters);
         }
 
         public string GetBaseName()

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -299,9 +299,9 @@ namespace QuantConnectStubsGenerator.Parser
             if (!avoidImplicitConversionTypes)
             {
                 // Symbol parameters can be both a Symbol or a string in most methods
-                if (parameter.Type.Namespace == "QuantConnect" && parameter.Type.Name == "Symbol")
+                if (parameter.Type.Equals(PythonType.SymbolType))
                 {
-                    parameter.Type = PythonType.CreateUnion(parameter.Type, new PythonType("str"), new PythonType("BaseContract", "QuantConnect.Data.Market"));
+                    parameter.Type = PythonType.ImplicitConversionParameterSymbolType;
                 }
 
                 // IDataConsolidator parameters can be either IDataConsolidator, PythonConsolidator or timedelta

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -277,6 +277,7 @@ namespace QuantConnectStubsGenerator.Parser
                     : paramText;
             }
             method.GenericType = genericType;
+            method.AvoidImplicitTypes = avoidImplicitConversionTypes;
             _currentClass.Methods.Add(method);
 
             ImprovePythonAccessorIfNecessary(method);


### PR DESCRIPTION
This adds support for  symbol implicit conversion for methods of a generic class that use the generic types as arguments types. This way the derived classes have a method declaration that substitutes Symbol with the Union type.

This follows up https://github.com/QuantConnect/Lean/pull/8723