### PR TITLE
Make enumerable parameters typing.List

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -407,7 +407,8 @@ namespace QuantConnect.Test
             Assert.AreEqual("typing.List[int]", constructor1.Parameters[0].Type.ToPythonString());
 
             var constructor2 = testClass.Methods.Where(x => x.Name == "__init__" && x.Parameters.Count == 2).Single();
-            Assert.AreEqual("typing.Iterable[int]", constructor2.Parameters[1].Type.ToPythonString());
+            // Enumerable parameters are always converted to List
+            Assert.AreEqual("typing.List[int]", constructor2.Parameters[1].Type.ToPythonString());
 
             var method1 = testClass.Methods.Single(x => x.Name == "Method1");
             Assert.AreEqual("typing.List[str]", method1.Parameters[0].Type.ToPythonString());

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -267,7 +267,7 @@ class TestClass(System.Object):
     """"""This class has no documentation.""""""
 
     @overload
-    def __init__(self, some_param: int, enumerable: typing.Iterable[int]) -> None:
+    def __init__(self, some_param: int, enumerable: typing.List[int]) -> None:
         ...
 
     @overload

--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -116,7 +116,7 @@ namespace QuantConnectStubsGenerator.Parser
         /// </summary>
         protected virtual void EnterClass(BaseTypeDeclarationSyntax node)
         {
-            _currentClass = _currentNamespace.GetClassByType(_typeConverter.GetType(node, true, true));
+            _currentClass = _currentNamespace.GetClassByType(_typeConverter.GetType(node, true, true, false));
         }
 
         private void ExitClass()

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -61,7 +61,7 @@ namespace QuantConnectStubsGenerator.Parser
 
         private Class ParseClass(BaseTypeDeclarationSyntax node)
         {
-            return new Class(_typeConverter.GetType(node, true, true))
+            return new Class(_typeConverter.GetType(node, true, true, false))
             {
                 Static = HasModifier(node, "static"),
                 Summary = ParseSummary(node),
@@ -106,7 +106,7 @@ namespace QuantConnectStubsGenerator.Parser
                 return types;
             }
 
-            var currentType = _typeConverter.GetType(node, true, true);
+            var currentType = _typeConverter.GetType(node, true, true, false);
             var skipTypeNormalization = !currentType.Namespace.StartsWith("QuantConnect");
 
             if (symbol.BaseType != null)

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -288,7 +288,8 @@ namespace QuantConnectStubsGenerator.Parser
         {
             avoidImplicitConversionTypes |= HasAttribute(syntax.AttributeLists, "StubsAvoidImplicits");
             var originalName = syntax.Identifier.Text;
-            var parameter = new Parameter(FormatParameterName(originalName), _typeConverter.GetType(syntax.Type, skipTypeNormalization: SkipTypeNormalization));
+            var parameter = new Parameter(FormatParameterName(originalName),
+                _typeConverter.GetType(syntax.Type, skipTypeNormalization: SkipTypeNormalization, isParameter: true));
 
             if (syntax.Modifiers.Any(modifier => modifier.Text == "params"))
             {


### PR DESCRIPTION
Make enumerable parameters typing.List for simpler use. Pythonnet converts them to Python Lists