### PR TITLE
Syntax checks improvements

### DIFF
--- a/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
+++ b/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.MethodParserTests
         }
 
         [Test]
-        public void CallableMethodsAcceptLambas()
+        public void CallableMethodsAcceptLambdas()
         {
             var testGenerator = new TestGenerator
             {

--- a/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
+++ b/QuantConnectStubsGenerator.Tests/MethodParserTests.cs
@@ -15,6 +15,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using static QuantConnectStubsGenerator.Tests.GeneratorTests;
 
 namespace QuantConnectStubsGenerator.Tests
@@ -61,6 +62,53 @@ namespace QuantConnect.MethodParserTests
 
             Assert.AreEqual(1, method.Parameters.Count);
             Assert.AreEqual("Union", method.Parameters[0].Type.Name);
+        }
+
+        [Test]
+        public void CallableMethodsAcceptLambas()
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    { "Test.cs", @"
+using System;
+
+namespace QuantConnect.MethodParserTests
+{
+    public class TestClass
+    {
+        public void TestMethod(Action<string> handler)
+        {
+        }
+    }
+}" }
+            }
+            };
+
+            var result = testGenerator.GenerateModelsPublic();
+
+            var namespaces = result.GetNamespaces().ToList();
+            Assert.AreEqual(2, namespaces.Count);
+
+            var baseNameSpace = namespaces.Single(x => x.Name == "QuantConnect");
+            var testNameSpace = namespaces.Single(x => x.Name == "QuantConnect.MethodParserTests");
+            var testClass = testNameSpace.GetClasses().Single();
+
+            var method = testClass.Methods.Single();
+
+            Assert.AreEqual("TestMethod", method.Name);
+
+            Assert.AreEqual(1, method.Parameters.Count);
+            var parameter = method.Parameters[0];
+            Assert.AreEqual("Callable", parameter.Type.Name);
+            Assert.AreEqual("typing", parameter.Type.Namespace);
+
+            Assert.AreEqual(2, parameter.Type.TypeParameters.Count);
+            Assert.AreEqual("str", parameter.Type.TypeParameters[0].Name);
+            Assert.IsNull(parameter.Type.TypeParameters[0].Namespace);
+            Assert.AreEqual("Any", parameter.Type.TypeParameters[1].Name);
+            Assert.AreEqual("typing", parameter.Type.TypeParameters[1].Namespace);
         }
     }
 }

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -351,11 +351,11 @@ class TestClass(System.Object):
     """"""This class has no documentation.""""""
 
     @property
-    def test_event(self) -> _EventContainer[typing.Callable[[System.Object, IndicatorDataPoint], None], None]:
+    def test_event(self) -> _EventContainer[typing.Callable[[System.Object, IndicatorDataPoint], typing.Any], typing.Any]:
         ...
 
     @test_event.setter
-    def test_event(self, value: _EventContainer[typing.Callable[[System.Object, IndicatorDataPoint], None], None]) -> None:
+    def test_event(self, value: _EventContainer[typing.Callable[[System.Object, IndicatorDataPoint], typing.Any], typing.Any]) -> None:
         ...
 
 class _EventContainer(typing.Generic[QuantConnect_Test__EventContainer_Callable, QuantConnect_Test__EventContainer_ReturnType]):

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -275,7 +275,8 @@ namespace QuantConnectStubsGenerator
                     }
 
                     var paramName = m.Parameters[0].Name;
-                    return paramName != "type" && paramName != "dataType" && paramName != "T";
+                    return paramName != "type" && paramName != "dataType" && paramName != "T" &&
+                        !m.Parameters.Any(p => p.Name == "handler" && p.Type == PythonType.Any);
                 })
                 .ToList();
 

--- a/QuantConnectStubsGenerator/Model/PythonType.cs
+++ b/QuantConnectStubsGenerator/Model/PythonType.cs
@@ -26,6 +26,7 @@ namespace QuantConnectStubsGenerator.Model
             CreateUnion(SymbolType, new PythonType("str"), new PythonType("BaseContract", "QuantConnect.Data.Market"));
 
         public static readonly PythonType Any = new PythonType("Any", "typing");
+        public static readonly PythonType None = new PythonType("None");
 
         public string Name { get; set; }
         public string Namespace { get; set; }

--- a/QuantConnectStubsGenerator/Parser/TypeConverter.cs
+++ b/QuantConnectStubsGenerator/Parser/TypeConverter.cs
@@ -115,7 +115,12 @@ namespace QuantConnectStubsGenerator.Parser
                         parameters.Add(GetType(parameter.Type, isParameter: isParameter));
                     }
 
-                    parameters.Add(GetType(namedTypeSymbol.DelegateInvokeMethod.ReturnType, isParameter: isParameter));
+                    var returnType = GetType(namedTypeSymbol.DelegateInvokeMethod.ReturnType, isParameter: isParameter);
+                    if (returnType.Equals(PythonType.None))
+                    {
+                        returnType = PythonType.Any;
+                    }
+                    parameters.Add(returnType);
 
                     return new PythonType("Callable", "typing")
                     {

--- a/QuantConnectStubsGenerator/Parser/TypeConverter.cs
+++ b/QuantConnectStubsGenerator/Parser/TypeConverter.cs
@@ -241,24 +241,13 @@ namespace QuantConnectStubsGenerator.Parser
 
                 if (type.Name == "IReadOnlyList" || type.Name == "IReadOnlyCollection")
                 {
-                    if (!isParameter)
+                    return new PythonType("Sequence", "typing")
                     {
-                        return new PythonType("Sequence", "typing")
-                        {
-                            TypeParameters = { NormalizeType(type.TypeParameters[0], isParameter) }
-                        };
-                    }
-                    isList = true;
+                        TypeParameters = { NormalizeType(type.TypeParameters[0], isParameter) }
+                    };
                 }
                 else if (type.Name == "IList" || type.Name == "List")
                 {
-                    if (!isParameter)
-                    {
-                        return new PythonType("List", "typing")
-                        {
-                            TypeParameters = { NormalizeType(type.TypeParameters[0], isParameter) }
-                        };
-                    }
                     isList = true;
                 }
                 else if (type.Name == "IEnumerable")


### PR DESCRIPTION
- Allow passing lambas as callable parameters to methods.
- Avoid removing some Python overloads that take a Python handler callback