### PR TITLE
Use IntEnum for C# enums

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -503,45 +503,6 @@ namespace QuantConnect.Test
             Assert.IsNull(internalFieldEvent);
         }
 
-        [Test]
-        public void GeneratesIntImplicitConversionOperatorForEnums()
-        {
-            var testGenerator = new TestGenerator
-            {
-                Files = new()
-                {
-                    {
-                        "Test.cs",
-                        @"
-using System;
-
-namespace QuantConnect.Test
-{
-    public enum TestEnum
-    {
-        Value1,
-        Value2,
-        Value3
-    }
-}"
-                    }
-                }
-            };
-
-            var result = testGenerator.GenerateModelsPublic();
-
-            var ns = result.GetNamespaces().Single(x => x.Name == "QuantConnect.Test");
-            var classes = ns.GetClasses().ToList();
-            var testEnum = classes.Single(x => x.Type.Name == "TestEnum");
-
-            Assert.IsTrue(testEnum.IsEnum());
-
-            var intImplicitConversionMethod = testEnum.Methods.SingleOrDefault(m => m.Name == "__int__");
-            Assert.IsNotNull(intImplicitConversionMethod);
-            Assert.AreEqual(0, intImplicitConversionMethod.Parameters.Count);
-            Assert.AreEqual(new PythonType("int"), intImplicitConversionMethod.ReturnType);
-        }
-
         internal class TestGenerator : Generator
         {
             public Dictionary<string, string> Files { get; set; }

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -105,7 +105,7 @@ namespace QuantConnect.Namespace2
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import abc
 
 import QuantConnect.Namespace1
@@ -125,7 +125,7 @@ class BaseClass(System.Object, QuantConnect.Namespace1.IInterface):
 ",
                 @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import abc
 
 import QuantConnect.Namespace1
@@ -187,7 +187,7 @@ namespace QuantConnect.Test
                 {
                 @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import typing
 
 import QuantConnect.Test
@@ -261,7 +261,7 @@ namespace QuantConnect.Test
                 {
                 @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import datetime
 import typing
 
@@ -326,7 +326,7 @@ namespace QuantConnect.Test
                 {
                 @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import typing
 
 import QuantConnect.Test
@@ -445,7 +445,7 @@ namespace QuantConnect.Test
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import abc
 
 import System.Collections
@@ -455,7 +455,7 @@ class IDictionary(System.Collections.ICollection, metaclass=abc.ABCMeta):
 ",
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import typing
 
 import System.Collections.Generic
@@ -468,7 +468,7 @@ class KeyValuePair(typing.Generic[System_Collections_Generic_KeyValuePair_TKey, 
 ",
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import typing
 
 import QuantConnect.Test
@@ -562,7 +562,7 @@ namespace QuantConnect.Test
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import QuantConnect
 import System
 
@@ -572,7 +572,7 @@ class Symbol(System.Object):
 ",
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import datetime
 import typing
 
@@ -764,7 +764,7 @@ namespace QuantConnect.Test
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import abc
 import typing
 
@@ -778,7 +778,7 @@ class IComparable(typing.Generic[System_IComparable_T], metaclass=abc.ABCMeta):
 ",
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import typing
 
 import QuantConnect.Test
@@ -989,7 +989,7 @@ namespace QuantConnect.TestNamespace
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import QuantConnect.TestNamespace
 import System
 
@@ -1053,7 +1053,7 @@ namespace QuantConnect.Namespace
                 {
                     @"
 from typing import overload
-from enum import Enum
+from enum import IntEnum
 import QuantConnect.Namespace
 import System
 

--- a/QuantConnectStubsGenerator/Model/Class.cs
+++ b/QuantConnectStubsGenerator/Model/Class.cs
@@ -42,11 +42,6 @@ namespace QuantConnectStubsGenerator.Model
             Type = type;
         }
 
-        public bool IsEnum()
-        {
-            return InheritsFrom.Any(type => type.ToPythonString() == "System.Enum");
-        }
-
         public IEnumerable<PythonType> GetUsedTypes()
         {
             var types = new HashSet<PythonType>();

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -69,17 +69,6 @@ namespace QuantConnectStubsGenerator.Parser
         {
         }
 
-        protected override void EnterClass(BaseTypeDeclarationSyntax node)
-        {
-            base.EnterClass(node);
-
-            // Pythonnet adds __int__() method to enums to allow implicit conversion to int
-            if (_currentClass.IsEnum())
-            {
-                AddIntImplicitOperatorMethod();
-            }
-        }
-
         public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
             PythonType genericType = null;

--- a/QuantConnectStubsGenerator/Renderer/ClassRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/ClassRenderer.cs
@@ -64,8 +64,9 @@ namespace QuantConnectStubsGenerator.Renderer
                 {
                     if (inherited[i].Equals("System.Enum", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        // 'Enum' is a python base type which is handled better by mypy if we used 'System' it assumes the enum value and causes a warning/missmatch
-                        inherited[i] = "Enum";
+                        // 'IntEnum' is a python base type which is handled better by mypy if we used 'System' it assumes the enum value and causes a warning/missmatch.
+                        // We use IntEnum to hint that the enum values are integers which is the case for all QuantConnect enums.
+                        inherited[i] = "IntEnum";
                     }
                 }
                 Write($"({string.Join(", ", inherited)})");

--- a/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
@@ -34,7 +34,7 @@ namespace QuantConnectStubsGenerator.Renderer
             // Fix for Jedi; Include import of typing instead of using typing.overload
             WriteLine("from typing import overload");
             // fix for python enums
-            WriteLine("from enum import Enum");
+            WriteLine("from enum import IntEnum");
 
             var usedTypes = ns
                 .GetParentClasses()


### PR DESCRIPTION
Use Python `IntEnum` instead of `Enum` for C# enums.
This allows hinting the int behaviour of our enums without the __int__ especial method.

Closes #84 