### PR TITLE
Parse and convert referenced code in C# XML docs

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -1087,6 +1087,160 @@ class TestClass(System.Object):
         ...
 ",
                 }).SetName("BracketsAreReplacedWithAngularBracketsInDocstringsToAvoidMarkdownIssues"),
+
+            // CodeReferencesInDocsAreSnakeCased
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Test1.cs",
+                        @"
+using QuantConnect.TestNamespace;
+
+namespace QuantConnect.TestNamespace
+{
+    public class ReferencedClass
+    {
+        public class InnerClass
+        {
+            public int TestField = 0;
+            public const int TestConstField = 0;
+            public static readonly int TestReadonlyField = 0;
+            public int TestReadonlyProperty { get; }
+            public int TestProperty { get; set; }
+
+            public int TestMethod1(int x, string y)
+            {
+                return x;
+            }
+            public int TestMethod2()
+            {
+                return 0;
+            }
+        }
+    }
+}
+
+namespace QuantConnect.Namespace
+{
+    public class TestClass
+    {
+        public ReferencedClass ReferencedClassInstance { get; set; }
+
+        public void ReferencedMethod()
+        {
+        }
+
+        /// <summary>
+        /// A method reference: <see cref=""ReferencedMethod""/>.
+        /// A param reference: <paramref name=""argName""/>.
+        /// A class reference: <see cref=""ReferencedClass""/>.
+        /// A nested class reference: <see cref=""ReferencedClass.InnerClass""/>.
+        /// A field reference: <see cref=""ReferencedClass.InnerClass.TestField""/>.
+        /// A const field reference: <see cref=""ReferencedClass.InnerClass.TestConstField""/>.
+        /// A readonly field reference <see cref=""ReferencedClass.InnerClass.TestReadonlyField""/>.
+        /// A readonly property reference <see cref=""ReferencedClass.InnerClass.TestReadonlyProperty""/>.
+        /// A property reference: <see cref=""ReferencedClass.InnerClass.TestProperty""/>.
+        /// A method with args reference: <see cref=""ReferencedClass.InnerClass.TestMethod1(int, string)""/>.
+        /// A method without args reference <see cref=""ReferencedClass.InnerClass.TestMethod2""/>.
+        /// </summary>
+        /// <param name=""argName"">Argument description. Reference in param node <see cref=""ReferencedMethod""/></param>
+        /// <returns>Return <paramref name=""argName""/> untouched. Reference in returns node <see cref=""ReferencedMethod""/></returns>
+        public int TestMethod(int argName)
+        {
+            return argName;
+        }
+    }
+}"
+                    },
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import IntEnum
+import QuantConnect.TestNamespace
+import System
+
+
+class ReferencedClass(System.Object):
+    """"""This class has no documentation.""""""
+
+    class InnerClass(System.Object):
+        """"""This class has no documentation.""""""
+
+        @property
+        def test_field(self) -> int:
+            ...
+
+        @test_field.setter
+        def test_field(self, value: int) -> None:
+            ...
+
+        TEST_CONST_FIELD: int = 0
+
+        TEST_READONLY_FIELD: int = 0
+
+        @property
+        def test_readonly_property(self) -> int:
+            ...
+
+        @property
+        def test_property(self) -> int:
+            ...
+
+        @test_property.setter
+        def test_property(self, value: int) -> None:
+            ...
+
+        def test_method_1(self, x: int, y: str) -> int:
+            ...
+
+        def test_method_2(self) -> int:
+            ...
+",
+                    @"
+from typing import overload
+from enum import IntEnum
+import QuantConnect.Namespace
+import QuantConnect.TestNamespace
+import System
+
+
+class TestClass(System.Object):
+    """"""This class has no documentation.""""""
+
+    @property
+    def referenced_class_instance(self) -> QuantConnect.TestNamespace.ReferencedClass:
+        ...
+
+    @referenced_class_instance.setter
+    def referenced_class_instance(self, value: QuantConnect.TestNamespace.ReferencedClass) -> None:
+        ...
+
+    def referenced_method(self) -> None:
+        ...
+
+    def test_method(self, arg_name: int) -> int:
+        """"""
+        A method reference: referenced_method.
+        A param reference: arg_name.
+        A class reference: ReferencedClass.
+        A nested class reference: ReferencedClass.InnerClass.
+        A field reference: ReferencedClass.InnerClass.test_field.
+        A const field reference: ReferencedClass.InnerClass.TEST_CONST_FIELD.
+        A readonly field reference ReferencedClass.InnerClass.TEST_READONLY_FIELD.
+        A readonly property reference ReferencedClass.InnerClass.test_readonly_property.
+        A property reference: ReferencedClass.InnerClass.test_property.
+        A method with args reference: ReferencedClass.InnerClass.test_method_1(int, string).
+        A method without args reference ReferencedClass.InnerClass.test_method_2.
+
+        :param arg_name: Argument description. Reference in param node referenced_method
+        :returns: Return arg_name untouched. Reference in returns node referenced_method.
+        """"""
+        ...
+",
+                }).SetName("CodeReferencesInDocsAreSnakeCased"),
         };
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -24,6 +24,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using QuantConnectStubsGenerator.Model;
 using QuantConnectStubsGenerator.Parser;
 using QuantConnectStubsGenerator.Renderer;
+using System.Xml;
+using QuantConnectStubsGenerator.Utility;
 
 namespace QuantConnectStubsGenerator
 {
@@ -98,7 +100,6 @@ namespace QuantConnectStubsGenerator
             // Perform post-processing on all parsed classes
             foreach (var ns in context.GetNamespaces())
             {
-
                 // Remove problematic method "GetMethodInfo" from System.Reflection.RuntimeReflectionExtensions
                 // KW arg is `del` which python is not a fan of. TODO: Make this post filtering more generic?
                 if (ns.Name == "System.Reflection")
@@ -109,7 +110,6 @@ namespace QuantConnectStubsGenerator
 
                     reflectionClass.Methods.Remove(badMethod);
                 }
-
 
                 foreach (var cls in ns.GetClasses())
                 {
@@ -123,9 +123,32 @@ namespace QuantConnectStubsGenerator
                 }
             }
 
+            // We do this in steps (post process classes and then get namespaces to import and generate summaries)
+            // because we need classes to be fully processed before we can generate summaries and determine imports
+            foreach (var ns in context.GetNamespaces())
+            {
+                ns.NamespacesToImport = GetNamespacesToImport(ns);
+                foreach (var cls in ns.GetClasses())
+                {
+                    GenerateSummaries(cls, context);
+                }
+            }
+
             // Create empty namespaces to fill gaps in between namespaces like "A.B" and "A.B.C.D"
             // This is needed to make import resolution work correctly
             CreateEmptyNamespaces(context);
+        }
+
+        private static List<string> GetNamespacesToImport(Namespace ns)
+        {
+            return ns
+                .GetParentClasses()
+                .SelectMany(cls => cls.GetUsedTypes())
+                .Where(type => type.Namespace != null)
+                .Select(type => type.Namespace)
+                .Distinct()
+                .OrderBy(namespaceToImport => namespaceToImport, StringComparer.Ordinal)
+                .ToList();
         }
 
         protected virtual IEnumerable<SyntaxTree> GetSyntaxTrees()
@@ -261,8 +284,6 @@ namespace QuantConnectStubsGenerator
             HandleSymbolGenericClass(cls, context);
 
             HandleGenericMethods(cls);
-
-            CleanUpSummaries(cls);
 
             var pythonMethodsToRemove = cls.Methods
                 .Where(m => m.File != null && m.File.EndsWith(".Python.cs"))
@@ -474,6 +495,63 @@ namespace QuantConnectStubsGenerator
         private string CleanUpSummary(string summary)
         {
             return summary != null ? _summaryCleanupRegex.Replace(summary, "<$1>") : null;
+        }
+
+        private void GenerateSummaries(Class cls, ParseContext context)
+        {
+            if (!cls.Type.Namespace.StartsWith("QuantConnect"))
+            {
+                return;
+            }
+
+            foreach (var entity in new CodeEntity[] { cls }.Concat(cls.Methods).Concat(cls.Properties))
+            {
+                if (entity.Documentation == null)
+                {
+                    continue;
+                }
+
+                var summaryNode = entity.Documentation["root"]["summary"];
+                if (summaryNode != null)
+                {
+                    entity.Summary = summaryNode.GetText(entity, context);
+                }
+
+                var xmlDocument = entity.Documentation.DocumentElement;
+                var summaryLines = new List<string>();
+                if (entity is Method method)
+                {
+                    foreach (XmlElement docParameter in xmlDocument.SelectNodes(".//param"))
+                    {
+                        var formattedDocParameterName = MethodParser.FormatParameterName(docParameter.Attributes["name"]?.Value);
+                        if (method.Parameters.Any(x => x.Name == formattedDocParameterName))
+                        {
+                            summaryLines.Add($":param {formattedDocParameterName}: {docParameter.GetText(entity, context)}");
+                        }
+                    }
+
+                    var returnsNode = xmlDocument["returns"];
+                    if (returnsNode != null)
+                    {
+                        var returnsText = returnsNode.GetText(entity, context);
+                        if (returnsText.Trim().Length > 0)
+                        {
+                            returnsText = returnsText.EndsWith(".") ? returnsText : returnsText + ".";
+                            summaryLines.Add($":returns: {returnsText}");
+                        }
+                    }
+
+                    if (summaryLines.Count > 0)
+                    {
+                        var summaryParamsText = string.Join("\n", summaryLines);
+                        entity.Summary = entity.Summary != null
+                            ? entity.Summary.TrimEnd() + "\n\n" + summaryParamsText
+                            : summaryParamsText;
+                    }
+                }
+
+                entity.Summary = CleanUpSummary(entity.Summary);
+            }
         }
 
         protected virtual TextWriter CreateWriter(string path)

--- a/QuantConnectStubsGenerator/Model/Class.cs
+++ b/QuantConnectStubsGenerator/Model/Class.cs
@@ -18,11 +18,9 @@ using System.Linq;
 
 namespace QuantConnectStubsGenerator.Model
 {
-    public class Class
+    public class Class : CodeEntity
     {
         public PythonType Type { get; }
-
-        public string Summary { get; set; }
 
         public bool Static { get; set; }
         public bool Interface { get; set; }

--- a/QuantConnectStubsGenerator/Model/CodeEntity.cs
+++ b/QuantConnectStubsGenerator/Model/CodeEntity.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System.Xml;
+
+namespace QuantConnectStubsGenerator.Model
+{
+    public enum CodeEntityType
+    {
+        Class,
+        Method,
+        Property,
+        Field
+    }
+
+    public abstract class CodeEntity
+    {
+        public string Summary { get; set; }
+
+        public XmlDocument Documentation { get; set; }
+    }
+}
+

--- a/QuantConnectStubsGenerator/Model/Method.cs
+++ b/QuantConnectStubsGenerator/Model/Method.cs
@@ -19,15 +19,13 @@ using System.Linq;
 
 namespace QuantConnectStubsGenerator.Model
 {
-    public class Method : IEquatable<Method>
+    public class Method : CodeEntity, IEquatable<Method>
     {
         public string Name { get; }
         public PythonType ReturnType { get; set; }
 
         public bool Static { get; set; }
         public bool Overload { get; set; }
-
-        public string Summary { get; set; }
 
         public string File { get; set; }
 
@@ -59,6 +57,7 @@ namespace QuantConnectStubsGenerator.Model
             Parameters = other.Parameters.ToList();
             GenericType = other.GenericType;
             DeprecationReason = other.DeprecationReason;
+            Documentation = other.Documentation;
         }
 
         public bool Equals(Method other)

--- a/QuantConnectStubsGenerator/Model/Namespace.cs
+++ b/QuantConnectStubsGenerator/Model/Namespace.cs
@@ -23,6 +23,8 @@ namespace QuantConnectStubsGenerator.Model
     {
         public string Name { get; }
 
+        public List<string> NamespacesToImport { get; set; }
+
         private readonly IDictionary<string, Class> _classes = new Dictionary<string, Class>();
 
         public Namespace(string name)

--- a/QuantConnectStubsGenerator/Model/Property.cs
+++ b/QuantConnectStubsGenerator/Model/Property.cs
@@ -15,7 +15,7 @@
 
 namespace QuantConnectStubsGenerator.Model
 {
-    public class Property
+    public class Property : CodeEntity
     {
         public string Name { get; }
 
@@ -29,8 +29,6 @@ namespace QuantConnectStubsGenerator.Model
 
         public string Value { get; set; }
 
-        public string Summary { get; set; }
-
         public string DeprecationReason { get; set; }
 
         public bool HasSetter { get; set; }
@@ -42,9 +40,8 @@ namespace QuantConnectStubsGenerator.Model
             Name = name;
         }
 
-        public Property(Property template, string name)
+        public Property(Property template, string name) : this(name)
         {
-            Name = name;
             Type = template.Type;
             Static = template.Static;
             Abstract = template.Abstract;
@@ -54,6 +51,7 @@ namespace QuantConnectStubsGenerator.Model
             DeprecationReason = template.DeprecationReason;
             HasSetter = template.HasSetter;
             Class = template.Class;
+            Documentation = template.Documentation;
         }
     }
 }

--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -41,16 +41,6 @@ namespace QuantConnectStubsGenerator.Parser
             _typeConverter = new TypeConverter(model);
         }
 
-        public override void VisitUsingDirective(UsingDirectiveSyntax node)
-        {
-            base.VisitUsingDirective(node);
-        }
-
-        public override void VisitUsingStatement(UsingStatementSyntax node)
-        {
-            base.VisitUsingStatement(node);
-        }
-
         /// <summary>
         /// Handles 'namespace QuantConnect.Indicators;' sintax
         /// </summary>
@@ -307,7 +297,7 @@ namespace QuantConnectStubsGenerator.Parser
                 var hasSummary = xmlSummary != null;
                 xmlSummary ??= doc.CreateElement("summary");
                 doc["root"].AppendChild(xmlSummary);
-                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + $"This {nameof(codeEntityType).ToString()} is protected."));
+                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + $"This {nameof(codeEntityType)} is protected."));
             }
 
             var deprecationReason = GetDeprecationReason(node);

--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -41,6 +41,16 @@ namespace QuantConnectStubsGenerator.Parser
             _typeConverter = new TypeConverter(model);
         }
 
+        public override void VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            base.VisitUsingDirective(node);
+        }
+
+        public override void VisitUsingStatement(UsingStatementSyntax node)
+        {
+            base.VisitUsingStatement(node);
+        }
+
         /// <summary>
         /// Handles 'namespace QuantConnect.Indicators;' sintax
         /// </summary>
@@ -199,13 +209,14 @@ namespace QuantConnectStubsGenerator.Parser
                             return "This member is marked as obsolete.";
                         }
 
-                        var reason = arguments[0].Expression.ToString().Trim('"');
+                        var reason = _model.GetConstantValue(arguments[0].Expression);
+                        var reasonMessage = reason.HasValue ? reason.Value as string : arguments[0].Expression.ToString();
 
                         // The stubs are meant to make writing algorithms easier
                         // If a member is not deprecated for algorithm use, we don't mark it as deprecated at all
-                        if (!reason.Contains("provided for algorithm use only"))
+                        if (!reasonMessage.Contains("provided for algorithm use only"))
                         {
-                            return reason;
+                            return reasonMessage;
                         }
                     }
                 }
@@ -218,7 +229,7 @@ namespace QuantConnectStubsGenerator.Parser
         /// Parses the documentation above a node to an XML element.
         /// If the documentation contains a summary, this is then accessible with element["summary"].
         /// </summary>
-        protected XmlElement ParseDocumentation(SyntaxNode node)
+        protected XmlDocument ParseDocumentation(SyntaxNode node)
         {
             var lines = node
                 .GetLeadingTrivia()
@@ -274,7 +285,7 @@ namespace QuantConnectStubsGenerator.Parser
                 doc.LoadXml("<root></root>");
             }
 
-            return doc["root"];
+            return doc;
         }
 
         /// <summary>
@@ -284,6 +295,31 @@ namespace QuantConnectStubsGenerator.Parser
         protected string AppendSummary(string currentSummary, string text)
         {
             return currentSummary != null ? currentSummary + "\n\n" + text : text;
+        }
+
+        protected XmlDocument GetXmlDocumentation(MemberDeclarationSyntax node, CodeEntityType codeEntityType)
+        {
+            var doc = ParseDocumentation(node);
+            var xmlSummary = doc["root"]["summary"];
+
+            if (HasModifier(node, "protected"))
+            {
+                var hasSummary = xmlSummary != null;
+                xmlSummary ??= doc.CreateElement("summary");
+                doc["root"].AppendChild(xmlSummary);
+                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + $"This {nameof(codeEntityType).ToString()} is protected."));
+            }
+
+            var deprecationReason = GetDeprecationReason(node);
+            if (deprecationReason != null)
+            {
+                var hasSummary = xmlSummary != null;
+                xmlSummary ??= doc.CreateElement("summary");
+                doc["root"].AppendChild(xmlSummary);
+                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + deprecationReason));
+            }
+
+            return doc;
         }
 
         /// <summary>

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using QuantConnectStubsGenerator.Model;
-using QuantConnectStubsGenerator.Utility;
 
 namespace QuantConnectStubsGenerator.Parser
 {
@@ -64,36 +63,12 @@ namespace QuantConnectStubsGenerator.Parser
             return new Class(_typeConverter.GetType(node, true, true, false))
             {
                 Static = HasModifier(node, "static"),
-                Summary = ParseSummary(node),
+                Documentation = GetXmlDocumentation(node, CodeEntityType.Class),
                 Interface = node is InterfaceDeclarationSyntax,
                 InheritsFrom = ParseInheritedTypes(node).ToList(),
                 MetaClass = ParseMetaClass(node),
                 AvoidImplicitTypes = HasAttribute(node.AttributeLists, "StubsAvoidImplicits")
             };
-        }
-
-        private string ParseSummary(BaseTypeDeclarationSyntax node)
-        {
-            string summary = null;
-
-            var doc = ParseDocumentation(node);
-            if (doc["summary"] != null)
-            {
-                summary = doc["summary"].GetText();
-            }
-
-            if (HasModifier(node, "protected"))
-            {
-                summary = AppendSummary(summary, "This class is protected.");
-            }
-
-            var deprecationReason = GetDeprecationReason(node);
-            if (deprecationReason != null)
-            {
-                summary = AppendSummary(summary, deprecationReason);
-            }
-
-            return summary;
         }
 
         private IEnumerable<PythonType> ParseInheritedTypes(BaseTypeDeclarationSyntax node)

--- a/QuantConnectStubsGenerator/Parser/PropertyParser.cs
+++ b/QuantConnectStubsGenerator/Parser/PropertyParser.cs
@@ -75,19 +75,9 @@ namespace QuantConnectStubsGenerator.Parser
                 Abstract = _currentClass.Interface || HasModifier(node, "abstract"),
                 Constant = true,
                 DeprecationReason = GetDeprecationReason(node),
-                Class = _currentClass
+                Class = _currentClass,
+                Documentation = GetXmlDocumentation(node, CodeEntityType.Property),
             };
-
-            var doc = ParseDocumentation(node);
-            if (doc["summary"] != null)
-            {
-                property.Summary = doc["summary"].GetText();
-            }
-
-            if (property.DeprecationReason != null)
-            {
-                property.Summary = AppendSummary(property.Summary, property.DeprecationReason);
-            }
 
             _currentClass.Properties.Add(property);
         }
@@ -126,24 +116,9 @@ namespace QuantConnectStubsGenerator.Parser
                 DeprecationReason = GetDeprecationReason(node),
                 HasSetter = (node.AccessorList != null && node.AccessorList.Accessors.Any(x => x.Keyword.Text == "set" && IsPublic(x.Modifiers)))
                     || (node is EventDeclarationSyntax eventNode && IsPublic(eventNode.Modifiers)),
-                Class = _currentClass
+                Class = _currentClass,
+                Documentation = GetXmlDocumentation(node, CodeEntityType.Property),
             };
-
-            var doc = ParseDocumentation(node);
-            if (doc["summary"] != null)
-            {
-                property.Summary = doc["summary"].GetText();
-            }
-
-            if (HasModifier(node, "protected"))
-            {
-                property.Summary = AppendSummary(property.Summary, "This property is protected.");
-            }
-
-            if (property.DeprecationReason != null)
-            {
-                property.Summary = AppendSummary(property.Summary, property.DeprecationReason);
-            }
 
             _currentClass.Properties.Add(property);
         }
@@ -175,28 +150,13 @@ namespace QuantConnectStubsGenerator.Parser
                     Constant = HasModifier(node, "const") || (HasModifier(node, "static") && HasModifier(node, "readonly")),
                     DeprecationReason = GetDeprecationReason(node),
                     Class = _currentClass,
-                    HasSetter = IsPublic(node.Modifiers)
+                    HasSetter = IsPublic(node.Modifiers),
+                    Documentation = GetXmlDocumentation(node, CodeEntityType.Field),
                 };
 
                 if (variable.Initializer != null)
                 {
                     property.Value = FormatValue(variable.Initializer.Value.ToString());
-                }
-
-                var doc = ParseDocumentation(node);
-                if (doc["summary"] != null)
-                {
-                    property.Summary = doc["summary"].GetText();
-                }
-
-                if (HasModifier(node, "protected"))
-                {
-                    property.Summary = AppendSummary(property.Summary, "This field is protected.");
-                }
-
-                if (property.DeprecationReason != null)
-                {
-                    property.Summary = AppendSummary(property.Summary, property.DeprecationReason);
                 }
 
                 _currentClass.Properties.Add(property);

--- a/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/NamespaceRenderer.cs
@@ -41,7 +41,7 @@ namespace QuantConnectStubsGenerator.Renderer
                 .SelectMany(cls => cls.GetUsedTypes())
                 .ToList();
 
-            RenderImports(usedTypes);
+            RenderImports(ns);
             RenderTypeAliases(usedTypes);
             RenderTypeVars(usedTypes);
 
@@ -50,15 +50,9 @@ namespace QuantConnectStubsGenerator.Renderer
             RenderClasses(ns);
         }
 
-        private void RenderImports(IEnumerable<PythonType> usedTypes)
+        private void RenderImports(Namespace ns)
         {
-            // Retrieve all used namespaces
-            var namespacesToImport = usedTypes
-                .Where(type => type.Namespace != null)
-                .Select(type => type.Namespace)
-                .Distinct()
-                .OrderBy(namespaceToImport => namespaceToImport, StringComparer.Ordinal)
-                .ToList();
+            var namespacesToImport = ns.NamespacesToImport;
 
             if (namespacesToImport.Count == 0)
             {
@@ -68,9 +62,9 @@ namespace QuantConnectStubsGenerator.Renderer
             var systemNamespaces = namespacesToImport.Where(ns => char.IsLower(ns[0]) && ns != "pandas").ToList();
             var nonSystemNamespaces = namespacesToImport.Except(systemNamespaces).ToList();
 
-            foreach (var ns in systemNamespaces)
+            foreach (var systemNs in systemNamespaces)
             {
-                WriteLine($"import {ns}");
+                WriteLine($"import {systemNs}");
             }
 
             if (systemNamespaces.Count > 0 && nonSystemNamespaces.Count > 0)
@@ -78,9 +72,9 @@ namespace QuantConnectStubsGenerator.Renderer
                 WriteLine();
             }
 
-            foreach (var ns in nonSystemNamespaces)
+            foreach (var nonSystemNs in nonSystemNamespaces)
             {
-                WriteLine($"import {ns}");
+                WriteLine($"import {nonSystemNs}");
             }
 
             WriteLine();

--- a/QuantConnectStubsGenerator/Utility/XmlExtensions.cs
+++ b/QuantConnectStubsGenerator/Utility/XmlExtensions.cs
@@ -13,14 +13,16 @@
  * limitations under the License.
 */
 
+using System.Linq;
 using System.Net;
 using System.Xml;
+using QuantConnectStubsGenerator.Model;
 
 namespace QuantConnectStubsGenerator.Utility
 {
     public static class XmlExtensions
     {
-        public static string GetText(this XmlElement element)
+        public static string GetText(this XmlElement element, CodeEntity entity, ParseContext context, bool adjustNames = true)
         {
             var clone = element.CloneNode(true);
 
@@ -31,27 +33,67 @@ namespace QuantConnectStubsGenerator.Utility
 
                 switch (child.Name)
                 {
+                    case "paramref":
                     case "typeparamref":
-                        newText = child.Attributes["name"].Value;
+                        newText = adjustNames ? child.Attributes["name"].InnerText.ToSnakeCase() : child.Attributes["name"].InnerText;
                         break;
                     case "see":
-                    {
-                        // Replace cref, paramref, langword and href tags with their content
-                        var attribute = child.Attributes["cref"]
-                                        ?? child.Attributes["paramref"]
-                                        ?? child.Attributes["langword"]
-                                        ?? child.Attributes["href"];
-
-                        newText = attribute != null ? attribute.InnerText : child.InnerText;
-
-                        // Convert "T:System.Object" to "System.Object"
-                        if (newText.Length > 2 && newText[1] == ':')
+                    case "seealso":
                         {
-                            newText = newText.Substring(2);
-                        }
+                            // Replace cref, paramref, langword and href tags with their content
+                            var attribute = child.Attributes["langword"] ?? child.Attributes["href"];
+                            if (attribute != null)
+                            {
+                                newText = attribute.InnerText;
+                            }
+                            else if ((attribute = child.Attributes["paramref"]) != null)
+                            {
+                                newText = adjustNames ? attribute.InnerText.ToSnakeCase() : attribute.InnerText;
+                            }
+                            else if ((attribute = child.Attributes["cref"]) != null)
+                            {
+                                newText = attribute.InnerText;
 
-                        break;
-                    }
+                                if (adjustNames)
+                                {
+                                    var parts = newText.Split('.');
+                                    var name = parts[^1];
+                                    var parenthesisIndex = parts[^1].IndexOf('(');
+                                    var isMethod = false;
+                                    if (parenthesisIndex != -1)
+                                    {
+                                        parts[^1] = name = name.Substring(0, parenthesisIndex);
+                                        isMethod = true;
+                                    }
+
+                                    var referencedEntity = GetCodeEntity(name, newText, parts, entity, context, isMethod);
+                                    if (referencedEntity != null)
+                                    {
+                                        if (referencedEntity is Method)
+                                        {
+                                            newText = newText.Replace(name, name.ToSnakeCase());
+                                        }
+                                        else if (referencedEntity is Property property)
+                                        {
+                                            newText = newText.Replace(name, name.ToSnakeCase(constant: property.Constant));
+                                        }
+                                    }
+                                    // else: null or a class, assume it's a class, no need to change anything
+                                }
+                            }
+                            else
+                            {
+                                newText = child.InnerText;
+                            }
+
+                            // Convert "T:System.Object" to "System.Object"
+                            if (newText.Length > 2 && newText[1] == ':')
+                            {
+                                newText = newText.Substring(2);
+                            }
+
+                            break;
+                        }
                 }
 
                 if (newText == null)
@@ -72,6 +114,97 @@ namespace QuantConnectStubsGenerator.Utility
             text = WebUtility.HtmlDecode(text);
 
             return text;
+        }
+
+        /// <summary>
+        /// This will try to find the referenced entity (class, method or property/field) in the XML documentation.
+        /// It will first look in the current class, then in the imported namespaces.
+        /// </summary>
+        private static CodeEntity GetCodeEntity(string name, string fullName, string[] parts, CodeEntity entity, ParseContext context, bool isMethod)
+        {
+            if (string.IsNullOrEmpty(name) || context == null)
+            {
+                return null;
+            }
+
+            var entityClass = entity switch
+            {
+                Class c => c,
+                Property p => p.Class,
+                Method m => m.Class,
+            };
+
+            if (parts.Length == 1)
+            {
+                var method = entityClass.Methods.FirstOrDefault(x => x.Name == parts[0]);
+                if (method != null)
+                {
+                    return method;
+                }
+
+                var property = entityClass.Properties.FirstOrDefault(x => x.Name == parts[0]);
+                if (property != null)
+                {
+                    return property;
+                }
+
+                return context.GetNamespaces()
+                    .Where(x => x.Name.StartsWith("QuantConnect"))
+                    .SelectMany(x => x.GetClasses())
+                    .FirstOrDefault(x => x.Type.Name == parts[0]);
+            }
+
+            var entityNamespace = context.GetNamespaceByName(entityClass.Type.Namespace);
+            var namespaces = context.GetNamespaces().Where(x => x.Name.StartsWith("QuantConnect")).ToList();
+            var currentNamespace = (Namespace)null;
+
+            foreach (var ns in namespaces)
+            {
+                currentNamespace = ns;
+
+                foreach (var cls in ns.GetClasses())
+                {
+                    foreach (var method in cls.Methods)
+                    {
+                        if (method.Name == name && BelongsToClass(fullName, cls))
+                        {
+                            if (ns.Name == entityNamespace.Name || entityNamespace.NamespacesToImport.Contains(ns.Name))
+                            {
+                                return method;
+                            }
+                        }
+                    }
+
+                    if (!isMethod)
+                    {
+                        foreach (var property in cls.Properties)
+                        {
+                            if (property.Name == name && BelongsToClass(fullName, cls))
+                            {
+                                if (ns.Name == entityNamespace.Name || entityNamespace.NamespacesToImport.Contains(ns.Name))
+                                {
+                                    return property;
+                                }
+                            }
+                        }
+
+                        if (cls.Type.Name == fullName)
+                        {
+                            if (ns.Name == entityNamespace.Name || entityNamespace.NamespacesToImport.Contains(ns.Name))
+                            {
+                                return cls;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool BelongsToClass(string fullName, Class cls)
+        {
+            return fullName.Substring(0, fullName.LastIndexOf('.')) == cls.Type.Name;
         }
     }
 }


### PR DESCRIPTION
Convert methods, properties and parameter's references to Python's snake case in docstrings.
The generator will detect references in the `see`, `seealso` and `paramref` XML tags

Closes #83 