### PR TITLE
Avoid external types as base classes

### DIFF
--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -169,7 +169,7 @@ namespace QuantConnect.Test
         }
     }
 
-    public class TestDerivedEnumerable1 : TestEnumerable
+    public class TestDerivedEnumerable1 : TestEnumerable1
     {
     }
 
@@ -194,9 +194,6 @@ import QuantConnect.Test
 import System
 import System.Collections.Generic
 
-TestEnumerable = typing.Any
-
-
 class TestEnumerable1(System.Object, typing.Iterable[int]):
     """"""This class has no documentation.""""""
 
@@ -206,8 +203,7 @@ class TestEnumerable1(System.Object, typing.Iterable[int]):
     def get_enumerator(self) -> System.Collections.Generic.IEnumerator[int]:
         ...
 
-
-class TestDerivedEnumerable1(TestEnumerable):
+class TestDerivedEnumerable1(QuantConnect.Test.TestEnumerable1):
     """"""This class has no documentation.""""""
 
 
@@ -578,6 +574,7 @@ import typing
 
 import QuantConnect
 import QuantConnect.Data.Market
+import QuantConnect.Securities
 import QuantConnect.Test
 import System
 import System.Collections.Generic
@@ -605,10 +602,10 @@ class TestGenericClass(typing.Generic[QuantConnect_Test_TestGenericClass_T1, Qua
 class TestClass(QuantConnect.Test.TestGenericClass[QuantConnect.Symbol, datetime.datetime]):
     """"""This class has no documentation.""""""
 
-    def test_method_1(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract], t_2_param: datetime.datetime) -> QuantConnect.Symbol:
+    def test_method_1(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract, QuantConnect.Securities.Security], t_2_param: datetime.datetime) -> QuantConnect.Symbol:
         ...
 
-    def test_method_3(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract], t_2_param: typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, typing.List[datetime.datetime]]]) -> typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, datetime.datetime]]:
+    def test_method_3(self, t_1_param: typing.Union[QuantConnect.Symbol, str, QuantConnect.Data.Market.BaseContract, QuantConnect.Securities.Security], t_2_param: typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, typing.List[datetime.datetime]]]) -> typing.List[System.Collections.Generic.Dictionary[QuantConnect.Symbol, datetime.datetime]]:
         ...
 "
                 }).SetName("GeneratesMethodsWithSymbolImplicitConversionForInheritedGenericClasses"),

--- a/QuantConnectStubsGenerator/Model/PythonType.cs
+++ b/QuantConnectStubsGenerator/Model/PythonType.cs
@@ -23,7 +23,8 @@ namespace QuantConnectStubsGenerator.Model
     {
         public static readonly PythonType SymbolType = new PythonType("Symbol", "QuantConnect");
         public static readonly PythonType ImplicitConversionParameterSymbolType =
-            CreateUnion(SymbolType, new PythonType("str"), new PythonType("BaseContract", "QuantConnect.Data.Market"));
+            CreateUnion(SymbolType, new PythonType("str"), new PythonType("BaseContract", "QuantConnect.Data.Market"),
+                new PythonType("Security", "QuantConnect.Securities"));
 
         public static readonly PythonType Any = new PythonType("Any", "typing");
         public static readonly PythonType None = new PythonType("None");


### PR DESCRIPTION
Avoid external types as base classes so that classes don't inherit from `typing.Any` if not necessary