### PR TITLE
Support implicit conversion from Symbol to str

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -504,6 +504,35 @@ namespace QuantConnect.Test
             Assert.IsNull(internalFieldEvent);
         }
 
+        [TestCase("implicit", true)]
+        [TestCase("explicit", false)]
+        public void StringConversionOperatorDeterminesStrInheritance(string keyword, bool shouldInheritFromStr)
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    { "TestClass.cs", $@"
+namespace QuantConnect
+{{
+    public class TestClass
+    {{
+        public static {keyword} operator string(TestClass obj)
+        {{
+            return obj.ToString();
+        }}
+    }}
+}}" }
+                }
+            };
+
+            var result = testGenerator.GenerateModelsPublic();
+
+            var testClass = result.GetNamespaceByName("QuantConnect").GetClasses().Single(c => c.Type.Name == "TestClass");
+
+            Assert.AreEqual(shouldInheritFromStr, testClass.InheritsFrom.Any(t => t.Name == "str" && t.Namespace == null));
+        }
+
         internal class TestGenerator : Generator
         {
             public Dictionary<string, string> Files { get; set; }

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -691,7 +691,7 @@ namespace QuantConnectStubsGenerator
             }
 
             var symbolGenericBaseClasses = cls.InheritsFrom
-                .Where(x => x.Namespace.StartsWith("QuantConnect") && x.TypeParameters.Count > 0 && x.TypeParameters.Any(y => y.Equals(PythonType.SymbolType)))
+                .Where(x => x.Namespace != null && x.Namespace.StartsWith("QuantConnect") && x.TypeParameters.Count > 0 && x.TypeParameters.Any(y => y.Equals(PythonType.SymbolType)))
                 .ToList();
 
             if (symbolGenericBaseClasses.Count == 0)

--- a/QuantConnectStubsGenerator/Parser/ClassParser.cs
+++ b/QuantConnectStubsGenerator/Parser/ClassParser.cs
@@ -60,15 +60,38 @@ namespace QuantConnectStubsGenerator.Parser
 
         private Class ParseClass(BaseTypeDeclarationSyntax node)
         {
+            var inheritsFrom = ParseInheritedTypes(node).ToList();
+
+            // If this class implicitly converts to string in C#, it means you can use it
+            // wherever a string is expected. We reflect that in Python by inheriting from str
+            if (HasImplicitConversionToString(node) && !inheritsFrom.Any(t => t.Name == "str" && t.Namespace == null))
+            {
+                inheritsFrom.Insert(0, new PythonType("str"));
+            }
+
             return new Class(_typeConverter.GetType(node, true, true, false))
             {
                 Static = HasModifier(node, "static"),
                 Documentation = GetXmlDocumentation(node, CodeEntityType.Class),
                 Interface = node is InterfaceDeclarationSyntax,
-                InheritsFrom = ParseInheritedTypes(node).ToList(),
+                InheritsFrom = inheritsFrom,
                 MetaClass = ParseMetaClass(node),
                 AvoidImplicitTypes = HasAttribute(node.AttributeLists, "StubsAvoidImplicits")
             };
+        }
+
+        private static bool HasImplicitConversionToString(BaseTypeDeclarationSyntax node)
+        {
+            if (node is not TypeDeclarationSyntax typeDecl)
+            {
+                return false;
+            }
+
+            return typeDecl.Members
+                .OfType<ConversionOperatorDeclarationSyntax>()
+                .Any(op => op.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
+                           && op.Type is PredefinedTypeSyntax predefined
+                           && predefined.Keyword.IsKind(SyntaxKind.StringKeyword));
         }
 
         private IEnumerable<PythonType> ParseInheritedTypes(BaseTypeDeclarationSyntax node)


### PR DESCRIPTION
Classes with implicit operator string in C# now inherit from str in the generated stubs

Closes #96 