### PR TITLE
Include generic methods

### DIFF
--- a/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
+++ b/QuantConnectStubsGenerator.Tests/GeneratorTests.cs
@@ -203,15 +203,89 @@ namespace QuantConnect.GenericMethodsTest
             Assert.IsNotNull(testClass.Properties.SingleOrDefault(x => x.Name == "History"));
 
             // The dispatch helper is non-generic and exposes __call__ + __getitem__.
-            var indexableClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_History");
+            var indexableClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_TestClass_History");
             Assert.AreEqual(0, indexableClass.Type.TypeParameters?.Count ?? 0);
             Assert.IsNotNull(indexableClass.Methods.SingleOrDefault(x => x.Name == "__getitem__"));
             Assert.IsNotNull(indexableClass.Methods.SingleOrDefault(x => x.Name == "__call__"));
 
             // The typed helper is generic and holds the Sequence[T]-returning overloads.
-            var typedClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_TypedHistory");
+            var typedClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_Typed_TestClass_History");
             Assert.AreNotEqual(0, typedClass.Type.TypeParameters?.Count ?? 0);
             Assert.AreEqual(2, typedClass.Methods.Count(x => x.Name == "__call__"));
+        }
+
+        [Test]
+        public void GenericMethodsInStaticExtensionClass()
+        {
+            var testGenerator = new TestGenerator
+            {
+                Files = new()
+                {
+                    { "Test.cs", @"
+namespace QuantConnect.GenericMethodsExtensionTest
+{
+    public static class TestExtensionsClass
+    {
+        public static int ExtensionMethod(this int target, string parameter)
+        {
+            return 1;
+        }
+        public static T ExtensionMethod<T>(this int target, T parameter)
+        {
+            return parameter;
+        }
+        public static PyObject ExtensionMethod<T>(this int target, int parameter)
+        {
+            return null;
+        }
+    }
+}" }
+                }
+            };
+
+            var result = testGenerator.GenerateModelsPublic();
+
+            var namespaces = result.GetNamespaces().ToList();
+            Assert.AreEqual(2, namespaces.Count);
+
+            var baseNameSpace = namespaces.Single(x => x.Name == "QuantConnect");
+            var testNameSpace = namespaces.Single(x => x.Name == "QuantConnect.GenericMethodsExtensionTest");
+
+            // The extension class is registered as a static class.
+            var extensionsClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "TestExtensionsClass");
+            Assert.IsTrue(extensionsClass.Static);
+            Assert.AreEqual(0, extensionsClass.Methods.Count);
+            Assert.AreEqual(0, extensionsClass.InnerClasses.Count);
+            var property = extensionsClass.Properties.SingleOrDefault(x => x.Name == "ExtensionMethod");
+            Assert.IsNotNull(property);
+            Assert.IsTrue(property.Static);
+
+            // The dispatch helper is non-generic and exposes __call__ + __getitem__.
+            var indexableClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_TestExtensionsClass_ExtensionMethod");
+            Assert.AreEqual(0, indexableClass.Type.TypeParameters?.Count ?? 0);
+            Assert.IsNotNull(indexableClass.Methods.SingleOrDefault(x => x.Name == "__getitem__"));
+
+            // The non-generic __call__ includes 'target' (the 'this' parameter) as its first parameter.
+            var dispatchCall = indexableClass.Methods.Single(x => x.Name == "__call__");
+            Assert.AreEqual(2, dispatchCall.Parameters.Count);
+            Assert.AreEqual("target", dispatchCall.Parameters[0].Name);
+            Assert.AreEqual("int", dispatchCall.Parameters[0].Type.Name);
+
+            // The property type must be of the indexable helper class type
+            Assert.AreEqual(property.Type, indexableClass.Type);
+
+            // The typed helper is generic and holds the Sequence[T]-returning overloads.
+            var typedClass = testNameSpace.GetClasses().Single(x => x.Type.Name == "_Typed_TestExtensionsClass_ExtensionMethod");
+            Assert.AreNotEqual(0, typedClass.Type.TypeParameters?.Count ?? 0);
+            Assert.AreEqual(2, typedClass.Methods.Count(x => x.Name == "__call__"));
+
+            // Each typed __call__ also carries 'target' (the 'this' parameter) as its first parameter.
+            foreach (var call in typedClass.Methods.Where(x => x.Name == "__call__"))
+            {
+                Assert.IsTrue(call.Parameters.Count >= 1);
+                Assert.AreEqual("target", call.Parameters[0].Name);
+                Assert.AreEqual("int", call.Parameters[0].Type.Name);
+            }
         }
 
         [Test]

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -1552,7 +1552,7 @@ class TestExtensionsClass(System.Object):
 "
                 }).SetName("GenericStaticMethods"),
 
-            // GenericStaticMethods
+            // GenericCombinedStaticAndInstanceMethods
             new TestCaseData(
                 new Dictionary<string, string>()
                 {
@@ -1564,7 +1564,7 @@ using System;
 namespace QuantConnect.Namespace
 {
     /// <summary>
-    /// The generated helper propery should be static because at least one of the overloads is static, even though there are also instance overloads.
+    /// The generated helper property should be static because at least one of the overloads is static, even though there are also instance overloads.
     /// </summary>
     public class TestClass
     {
@@ -1633,12 +1633,125 @@ class _TestClass_TestMethod:
 
 class TestClass(System.Object):
     """"""
-    The generated helper propery should be static because at least one of the overloads is static, even though there are also instance overloads.
+    The generated helper property should be static because at least one of the overloads is static, even though there are also instance overloads.
     """"""
 
     test_method: QuantConnect.Namespace._TestClass_TestMethod
 "
                 }).SetName("GenericCombinedStaticAndInstanceMethods"),
+
+            // AddsLenMethodToCountableEnumerables
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Test1.cs",
+                        @"
+using System;
+
+namespace QuantConnect.Namespace
+{
+    
+    public class TestEnumerable1 : System.Collections.IEnumerable
+    {
+        public int Count { get; }
+        public IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class TestEnumerable2 : System.Collections.Generic.IEnumerable<int>
+    {
+        public int Count { get; }
+        public IEnumerator<int> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public class TestBaseEnumerable : System.Collections.Generic.IEnumerable<int>
+    {
+        public IEnumerator<int> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public class TestDerivedEnumerable : TestBaseEnumerable
+    {
+        public int Count { get; }
+    }
+}"
+                    },
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import IntEnum
+import typing
+
+import QuantConnect.Namespace
+import System
+import System.Collections
+
+
+class TestEnumerable1(System.Object, System.Collections.IEnumerable):
+    """"""This class has no documentation.""""""
+
+    @property
+    def count(self) -> int:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def get_enumerator(self) -> typing.Any:
+        ...
+
+
+class TestEnumerable2(System.Object, typing.Iterable[int]):
+    """"""This class has no documentation.""""""
+
+    @property
+    def count(self) -> int:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def get_enumerator(self) -> typing.Any:
+        ...
+
+
+class TestBaseEnumerable(System.Object, typing.Iterable[int]):
+    """"""This class has no documentation.""""""
+
+    def get_enumerator(self) -> typing.Any:
+        ...
+
+
+class TestDerivedEnumerable(QuantConnect.Namespace.TestBaseEnumerable):
+    """"""This class has no documentation.""""""
+
+    @property
+    def count(self) -> int:
+        ...
+
+    def __len__(self) -> int:
+        ...
+"
+                }).SetName("AddsLenMethodToCountableEnumerables"),
         };
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator.Tests/RendererTests.cs
+++ b/QuantConnectStubsGenerator.Tests/RendererTests.cs
@@ -1403,6 +1403,242 @@ class _EventContainer(typing.Generic[QuantConnect_Namespace__EventContainer_Call
         ...
 ",
                 }).SetName("CodeReferencesInDocsAreSnakeCased"),
+
+            // GenericMethods
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Test1.cs",
+                        @"
+using System;
+
+namespace QuantConnect.Namespace
+{
+    
+    public class TestClass
+    {
+        public int History(string parameter)
+        {
+            return 1;
+        }
+        public T History<T>(T parameter)
+        {
+            return parameter;
+        }
+        public PyObject History<T>(int parameter)
+        {
+            return null;
+        }
+    }
+}"
+                    },
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import IntEnum
+import typing
+
+import QuantConnect.Namespace
+import System
+
+QuantConnect_Namespace_TestClass_History_T = typing.TypeVar(""QuantConnect_Namespace_TestClass_History_T"")
+
+
+class _Typed_TestClass_History(typing.Generic[QuantConnect_Namespace_TestClass_History_T]):
+    """"""""""""
+
+    @overload
+    def __call__(self, parameter: QuantConnect_Namespace_TestClass_History_T) -> QuantConnect_Namespace_TestClass_History_T:
+        ...
+
+    @overload
+    def __call__(self, parameter: int) -> typing.Any:
+        ...
+
+
+class _TestClass_History:
+    """"""""""""
+
+    @overload
+    def __call__(self, parameter: str) -> int:
+        ...
+
+    def __getitem__(self, type: typing.Type[QuantConnect_Namespace_TestClass_History_T]) -> QuantConnect.Namespace._Typed_TestClass_History[QuantConnect_Namespace_TestClass_History_T]:
+        ...
+
+
+class TestClass(System.Object):
+    """"""This class has no documentation.""""""
+
+    @property
+    def history(self) -> QuantConnect.Namespace._TestClass_History:
+        ...
+"
+
+                }).SetName("GenericMethods"),
+
+            // GenericStaticMethods
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Test1.cs",
+                        @"
+using System;
+
+namespace QuantConnect.Namespace
+{    
+    public static class TestExtensionsClass
+    {
+        public static int ExtensionMethod(this int target, string parameter)
+        {
+            return 1;
+        }
+        public static T ExtensionMethod<T>(this int target, T parameter)
+        {
+            return parameter;
+        }
+        public static PyObject ExtensionMethod<T>(this int target, int parameter)
+        {
+            return null;
+        }
+    }
+}"
+                    },
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import IntEnum
+import typing
+
+import QuantConnect.Namespace
+import System
+
+QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T = typing.TypeVar(""QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T"")
+
+
+class _Typed_TestExtensionsClass_ExtensionMethod(typing.Generic[QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T]):
+    """"""""""""
+
+    @overload
+    def __call__(self, target: int, parameter: QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T) -> QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T:
+        ...
+
+    @overload
+    def __call__(self, target: int, parameter: int) -> typing.Any:
+        ...
+
+
+class _TestExtensionsClass_ExtensionMethod:
+    """"""""""""
+
+    @overload
+    def __call__(self, target: int, parameter: str) -> int:
+        ...
+
+    def __getitem__(self, type: typing.Type[QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T]) -> QuantConnect.Namespace._Typed_TestExtensionsClass_ExtensionMethod[QuantConnect_Namespace_TestExtensionsClass_ExtensionMethod_T]:
+        ...
+
+
+class TestExtensionsClass(System.Object):
+    """"""This class has no documentation.""""""
+
+    extension_method: QuantConnect.Namespace._TestExtensionsClass_ExtensionMethod
+"
+                }).SetName("GenericStaticMethods"),
+
+            // GenericStaticMethods
+            new TestCaseData(
+                new Dictionary<string, string>()
+                {
+                    {
+                        "Test1.cs",
+                        @"
+using System;
+
+namespace QuantConnect.Namespace
+{
+    /// <summary>
+    /// The generated helper propery should be static because at least one of the overloads is static, even though there are also instance overloads.
+    /// </summary>
+    public class TestClass
+    {
+        // Instance methods
+        public int TestMethod(string parameter)
+        {
+            return 1;
+        }
+        public T TestMethod<T>(T parameter)
+        {
+            return parameter;
+        }
+
+        // Static methods
+        public static int TestMethod(this int target, string parameter)
+        {
+            return 1;
+        }
+        public static T TestMethod<T>(this int target, T parameter)
+        {
+            return parameter;
+        }
+    }
+}"
+                    },
+                },
+                new[]
+                {
+                    @"
+from typing import overload
+from enum import IntEnum
+import typing
+
+import QuantConnect.Namespace
+import System
+
+QuantConnect_Namespace_TestClass_TestMethod_T = typing.TypeVar(""QuantConnect_Namespace_TestClass_TestMethod_T"")
+
+
+class _Typed_TestClass_TestMethod(typing.Generic[QuantConnect_Namespace_TestClass_TestMethod_T]):
+    """"""""""""
+
+    @overload
+    def __call__(self, parameter: QuantConnect_Namespace_TestClass_TestMethod_T) -> QuantConnect_Namespace_TestClass_TestMethod_T:
+        ...
+
+    @overload
+    def __call__(self, target: int, parameter: QuantConnect_Namespace_TestClass_TestMethod_T) -> QuantConnect_Namespace_TestClass_TestMethod_T:
+        ...
+
+
+class _TestClass_TestMethod:
+    """"""""""""
+
+    @overload
+    def __call__(self, parameter: str) -> int:
+        ...
+
+    @overload
+    def __call__(self, target: int, parameter: str) -> int:
+        ...
+
+    def __getitem__(self, type: typing.Type[QuantConnect_Namespace_TestClass_TestMethod_T]) -> QuantConnect.Namespace._Typed_TestClass_TestMethod[QuantConnect_Namespace_TestClass_TestMethod_T]:
+        ...
+
+
+class TestClass(System.Object):
+    """"""
+    The generated helper propery should be static because at least one of the overloads is static, even though there are also instance overloads.
+    """"""
+
+    test_method: QuantConnect.Namespace._TestClass_TestMethod
+"
+                }).SetName("GenericCombinedStaticAndInstanceMethods"),
         };
 
         private class TestGenerator : Generator

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -293,6 +293,8 @@ namespace QuantConnectStubsGenerator
 
             HandleGenericMethods(cls, context);
 
+            HandleCountableEnumerables(cls, context);
+
             // Precompute non-PyObject signatures once to keep the filter O(N) instead of O(N²).
             // We classify "C# equivalent" by the absence of a PyObject parameter rather than by
             // ".Python.cs" file suffix so that partial classes declaring PyObject overloads in
@@ -355,6 +357,31 @@ namespace QuantConnectStubsGenerator
                 .ToHashSet();
             cls.Methods.RemoveWhere(m => m.DeprecationReason != null
                 && liveOverloadSignatures.Contains((m.Name, m.ReturnType)));
+        }
+
+        private static bool IsEnumerable(PythonType type)
+        {
+            return (type.Name == "IEnumerable" && type.Namespace == "System.Collections")
+                || (type.Name == "Iterable" && type.Namespace == "typing");
+        }
+
+        private static bool IsEnumerable(Class cls, ParseContext context)
+        {
+            return cls.InheritsFrom.Any(IsEnumerable)
+                || cls.GetBaseClasses(context).Any(c => IsEnumerable(c, context));
+        }
+
+        private void HandleCountableEnumerables(Class cls, ParseContext context)
+        {
+            if (cls.Methods.Any(m => m.Name == "__len__") ||
+                !cls.Properties.Any(p => p.Name.Equals("Count", StringComparison.InvariantCultureIgnoreCase)) ||
+                !IsEnumerable(cls, context))
+            {
+                return;
+            }
+
+            var lenMethod = new Method("__len__", new PythonType("int")) { Class = cls };
+            cls.Methods.Add(lenMethod);
         }
 
         private void MarkOverloads(Class cls)

--- a/QuantConnectStubsGenerator/Generator.cs
+++ b/QuantConnectStubsGenerator/Generator.cs
@@ -500,8 +500,8 @@ namespace QuantConnectStubsGenerator
 
                 // Helper classes — both hoisted to namespace level with private names so they
                 // don't clutter QCAlgorithm's inner-class namespace in IDE autocomplete (issue #82).
-                var indexableClassName = $"_{genericMethodName}";
-                var typedClassName = $"_Typed{genericMethodName}";
+                var indexableClassName = $"_{cls.Type.Name}_{genericMethodName}";
+                var typedClassName = $"_Typed_{cls.Type.Name}_{genericMethodName}";
                 var typedClassType = new PythonType(typedClassName, cls.Type.Namespace) { TypeParameters = [genericType] };
                 var newGenericClass = new Class(typedClassType) { Summary = string.Empty };
                 var newIndexableClass = new Class(new PythonType(indexableClassName, cls.Type.Namespace)) { Summary = string.Empty };
@@ -509,7 +509,7 @@ namespace QuantConnectStubsGenerator
                 // PyObject wrapper overloads first so the DataFrame-returning variants take
                 // precedence in mypy/pyright overload resolution when an arg matches both a
                 // typed C# overload (e.g. History(Symbol, int, Resolution)) and the wrapper.
-                var allMethods = cls.Methods.Where(x => x.Name == genericMethodName)
+                var allMethods = cls.Methods.Where(x => x.Name.Equals(genericMethodName, StringComparison.InvariantCultureIgnoreCase))
                     .OrderBy(x => x.HasPyObjectParameter ? 0 : 1)
                     .ToList();
 
@@ -548,7 +548,7 @@ namespace QuantConnectStubsGenerator
                     .Select(tp => tp.ToPythonString())
                     .ToHashSet();
 
-                foreach (var methods in allMethods)
+                foreach (var method in allMethods)
                 {
                     // Skip C# overloads whose first parameter is fully covered by a wrapper
                     // overload (e.g. History(IEnumerable<Symbol>, ...) is covered by
@@ -556,18 +556,18 @@ namespace QuantConnectStubsGenerator
                     // If any flattened type is NOT in the wrapper's set (e.g. a Symbol
                     // first parameter that the wrapper's tickers Union does not include),
                     // keep the C# overload so its distinct return type is preserved.
-                    if (!methods.IsGeneric
+                    if (!method.IsGeneric
                         && pythonFirstParamTypes.Count > 0
-                        && !methods.HasPyObjectParameter
-                        && methods.Parameters.Count > 0
-                        && FlattenUnion(methods.Parameters[0].Type).All(t => pythonFirstParamTypes.Contains(t.ToPythonString())))
+                        && !method.HasPyObjectParameter
+                        && method.Parameters.Count > 0
+                        && FlattenUnion(method.Parameters[0].Type).All(t => pythonFirstParamTypes.Contains(t.ToPythonString())))
                     {
                         continue;
                     }
 
-                    var targetClass = methods.IsGeneric ? newGenericClass : newIndexableClass;
-                    var callMethod = new Method("__call__", methods) { Overload = true };
-                    if (methods.HasPyObjectParameter)
+                    var targetClass = method.IsGeneric ? newGenericClass : newIndexableClass;
+                    var callMethod = new Method("__call__", method) { Overload = true, Static = false, Class = targetClass };
+                    if (method.HasPyObjectParameter)
                     {
                         // Replace the Parameter instance (don't mutate — the original is shared
                         // with cls.Methods and mutating would desync its hash there).
@@ -596,6 +596,8 @@ namespace QuantConnectStubsGenerator
                 {
                     Type = newIndexableClass.Type,
                     Class = cls,
+                    Static = cls.Static || allMethods.Any(m => m.Static), // If any overload is static, the property must be static so it's accessible from the class.
+                    IsGenericMethodGroupingProperty = true
                 };
                 cls.Properties.Add(property);
 
@@ -605,7 +607,10 @@ namespace QuantConnectStubsGenerator
                 ns.RegisterClass(newGenericClass);
 
                 // remove those we've moved around
-                cls.Methods.RemoveWhere(x => x.Name.Equals(genericMethodName, StringComparison.InvariantCultureIgnoreCase));
+                foreach (var method in allMethods)
+                {
+                    cls.Methods.Remove(method);
+                }
             }
         }
 

--- a/QuantConnectStubsGenerator/Model/Property.cs
+++ b/QuantConnectStubsGenerator/Model/Property.cs
@@ -35,6 +35,8 @@ namespace QuantConnectStubsGenerator.Model
 
         public Class Class { get; set; }
 
+        public bool IsGenericMethodGroupingProperty { get; set; }
+
         public Property(string name)
         {
             Name = name;
@@ -52,6 +54,7 @@ namespace QuantConnectStubsGenerator.Model
             HasSetter = template.HasSetter;
             Class = template.Class;
             Documentation = template.Documentation;
+            IsGenericMethodGroupingProperty = template.IsGenericMethodGroupingProperty;
         }
     }
 }

--- a/QuantConnectStubsGenerator/Parser/BaseParser.cs
+++ b/QuantConnectStubsGenerator/Parser/BaseParser.cs
@@ -297,7 +297,7 @@ namespace QuantConnectStubsGenerator.Parser
                 var hasSummary = xmlSummary != null;
                 xmlSummary ??= doc.CreateElement("summary");
                 doc["root"].AppendChild(xmlSummary);
-                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + $"This {nameof(codeEntityType)} is protected."));
+                xmlSummary.AppendChild(doc.CreateTextNode((!hasSummary ? "" : "\n\n") + $"This {codeEntityType} is protected."));
             }
 
             var deprecationReason = GetDeprecationReason(node);

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -74,12 +74,6 @@ namespace QuantConnectStubsGenerator.Parser
             PythonType genericType = null;
             if (node.TypeParameterList != null)
             {
-                if (node.TypeParameterList.Parameters.Count > 1
-                    || !node.Identifier.Text.Equals("history", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    // skip, multiple generics or any different to history, we don't expect users to use those
-                    return;
-                }
                 var parameterType = node.TypeParameterList.Parameters.First();
                 genericType = _typeConverter.GetType(parameterType, skipTypeNormalization: SkipTypeNormalization);
             }
@@ -339,10 +333,11 @@ namespace QuantConnectStubsGenerator.Parser
                 _currentClass.Methods.Remove(existing);
             }
 
-            _currentClass.Methods.Add(method);
-
             ImprovePythonAccessorIfNecessary(method);
             ImproveDictionaryDefinitionIfNecessary(node, method);
+
+            // Add the method to the current class after all improvements, so the final definition is use for the hash code generation for the Class.Methods hashset
+            _currentClass.Methods.Add(method);
 
             return method;
         }

--- a/QuantConnectStubsGenerator/Parser/MethodParser.cs
+++ b/QuantConnectStubsGenerator/Parser/MethodParser.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Linq;
-using System.Xml;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using QuantConnectStubsGenerator.Model;

--- a/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
+++ b/QuantConnectStubsGenerator/Renderer/PropertyRenderer.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using QuantConnectStubsGenerator.Model;
@@ -55,9 +53,11 @@ namespace QuantConnectStubsGenerator.Renderer
         private bool ShouldSkip(Property property)
         {
             // Python.Net will favor snake-cased methods over properties,
-            // so we skip properties what match an existing method's name
-
-            return property.Class.GetClassAndBaseClasses(Context).Any(cls => cls.Methods.Any(method => method.Name == property.Name));
+            // so we skip properties what match an existing method's name.
+            // Although, we make an exception for properties that are actually 
+            // just grouping multiple generic method overloads under a single C# property name,
+            // since all methods will be grouped under it (see Generator.HandleGenericMethods).
+            return !property.IsGenericMethodGroupingProperty && property.Class.GetClassAndBaseClasses(Context).Any(cls => cls.Methods.Any(method => method.Name == property.Name));
         }
 
         private static Property GetSnakeCasedProperty(Property property)


### PR DESCRIPTION
- Include generic methods in stubs
- Add  `__len__` method to countable enumerables (`IEnumerable` implementations with `Count` property) 